### PR TITLE
Small changes for ui.stampy.ai deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ $ npm run dev
 $ npm run deploy
 ```
 
-Live demo: https://stampy-ui.aprillion.workers.dev
+Live demo: https://ui.stampy.ai

--- a/app/components/question.tsx
+++ b/app/components/question.tsx
@@ -3,6 +3,7 @@ import AutoHeight from 'react-auto-height'
 import type {Question} from '~/stampy'
 import type useQuestionStateInUrl from '~/hooks/useQuestionStateInUrl'
 import {tmpPageId} from '~/hooks/useQuestionStateInUrl'
+import iconPen from '~/assets/icons/pen.svg'
 
 export default function Question({
   questionProps,
@@ -13,7 +14,7 @@ export default function Question({
   onLazyLoadQuestion: (question: Question) => void
   onToggle: ReturnType<typeof useQuestionStateInUrl>['toggleQuestion']
 }) {
-  const {pageid, title, text, questionState} = questionProps
+  const {pageid, title, text, answerEditLink, questionState} = questionProps
   const refreshOnToggleAfterLoading = useRef(false)
 
   useEffect(() => {
@@ -47,10 +48,21 @@ export default function Question({
         <button className="transparent-button">{title}</button>
       </h2>
       <AutoHeight>
-        <div
-          className="answer"
-          dangerouslySetInnerHTML={{__html: isExpanded ? text || '<p>Loading...</p>' : ''}}
-        />
+        <div className="answer">
+          {isExpanded && (
+            <>
+              <div dangerouslySetInnerHTML={{__html: text || '<p>Loading...</p>'}} />
+              <div className="actions">
+                {answerEditLink && (
+                  // TODO: on the first click (remember in localstorage), display a disclaimer popup text from https://stampy.ai/wiki/Edit_popup
+                  <a href={answerEditLink} target="_blank" title="edit this answer on the wiki">
+                    <img alt="" src={iconPen} />
+                  </a>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       </AutoHeight>
     </article>
   )

--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -16,7 +16,7 @@ function updateQuestionMap(question: Question, map: Map<Question['pageid'], Ques
   for (const {pageid, title} of question.relatedQuestions) {
     if (!pageid || map.has(pageid)) continue
 
-    map.set(pageid, {title, pageid, text: null, relatedQuestions: []})
+    map.set(pageid, {title, pageid, text: null, answerEditLink: null, relatedQuestions: []})
   }
 }
 
@@ -53,6 +53,7 @@ export default function useQuestionStateInUrl(initialQuestions: Question[]) {
       pageid,
       title: '...',
       text: null,
+      answerEditLink: null,
       relatedQuestions: [],
       ...questionMap.get(pageid),
       questionState,
@@ -108,7 +109,13 @@ export default function useQuestionStateInUrl(initialQuestions: Question[]) {
       }
     }
     // else load new question
-    const tmpQuestion = {pageid: tmpPageId, title, text: null, relatedQuestions: []}
+    const tmpQuestion = {
+      pageid: tmpPageId,
+      title,
+      text: null,
+      answerEditLink: null,
+      relatedQuestions: [],
+    }
     onLazyLoadQuestion(tmpQuestion)
     toggleQuestion(tmpQuestion, {moveToTop: true})
 

--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -41,7 +41,7 @@ export default function useQuestionStateInUrl(initialQuestions: Question[]) {
   }, [transition.location])
 
   useEffect(() => {
-    document.title = stateString ? `Stampy in Test - ${stateString}` : `Stampy in Test`
+    document.title = stateString ? `Stampy in Test - ${stateString}` : `Stampy (alpha)`
   }, [stateString])
 
   const initialCollapsedState = useMemo(

--- a/app/root.css
+++ b/app/root.css
@@ -275,6 +275,11 @@ article > h2:hover::after {
   margin: var(--paddingSides);
 }
 
+.answer blockquote {
+  padding-left: 16px;
+  font-style: italic;
+}
+
 .answer .card-shortdesc,
 .answer .card-show-longdesc,
 .answer .card-hide-longdesc {

--- a/app/root.css
+++ b/app/root.css
@@ -191,7 +191,7 @@ main {
 article {
   background-color: var(--bgColorQuestionAnswer);
   border-radius: 2px;
-  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
   transition: margin 400ms;
 }
 

--- a/app/root.css
+++ b/app/root.css
@@ -281,6 +281,18 @@ article > h2:hover::after {
   display: none;
 }
 
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: 16px;
+  gap: 16px;
+}
+
+.actions img {
+  width: 24px;
+  height: 24px;
+}
+
 article.related {
   margin-left: var(--paddingSides);
   max-height: 999px;

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -51,9 +51,7 @@ export default function App() {
         </Link>
         <div className="intro">
           <h1>
-            Hi, I'm <span className="highlight">Stampy!</span>
-            <br />
-            (in test environment)
+            Hi, I'm <span className="highlight">Stampy!</span> (alpha version)
           </h1>
           <div dangerouslySetInnerHTML={{__html: intro}} />
         </div>


### PR DESCRIPTION
Fixed link to http://ui.stampy.ai in README, shadows in Win Chrome, ... and added the pencil icon as a link to edit the answer on wiki (without popup yet, just a link that opens on new tab).

<img width="1110" alt="Screenshot 2022-06-30 at 19 14 13" src="https://user-images.githubusercontent.com/1087670/176748672-4cada757-006b-40cb-82d5-690f50a38886.png">
