### PR TITLE
trigger on pr merge/close

### DIFF
--- a/.github/workflows/gen-encodings-deploy.yml
+++ b/.github/workflows/gen-encodings-deploy.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "* 0 * * *"
+  pull_request:
+    types:
+      - closed
 env:
   filepath: public/assets
   filename: stampy-questions-encodings.json
@@ -38,8 +41,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Restore stampy-ui repository code
+        if: github.event.pull_request.merged == 'true' || steps.check.outputs.changed == 'true'
         uses: actions/checkout@v3
       - name: Deploy to Cloudflare
+        if: github.event.pull_request.merged == 'true' || steps.check.outputs.changed == 'true'
         run: |
           cat wrangler.toml.template | sed s/{CLOUDFLARE_ACCT_ID}/${{ secrets.CLOUDFLARE_ACCT_ID }}/ | sed s/{STAMPY_KV_ID}/${{ secrets.STAMPY_KV_ID }}/ > wrangler.toml
           npm install


### PR DESCRIPTION
Added trigger on PR close. Tested on my repo's main branch. Screenshot of run by 3 triggers: manual, scheduled, and PR merge/close. 
<img width="914" alt="Screen Shot 2022-07-11 at 11 44 31 AM" src="https://user-images.githubusercontent.com/38997995/178338410-1c9cba82-9fc5-437a-937b-8eb40a7ab9c6.png">

It doesn't seem to be called when a PR is closed without merging. I included in a couple checks to deploy only if encodings changed or a merge occurred. Might be harmless to remove and deploy even when no change... ie when scheduled. Anyway, left it there for you to decide how/which you want to use.

