### PR TITLE
Tweak title, background, icons for noLogo

### DIFF
--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -1,6 +1,6 @@
 import {useState, useRef, useEffect, useMemo, useCallback} from 'react'
 import type {MouseEvent} from 'react'
-import {useSearchParams, useTransition} from '@remix-run/react'
+import {useSearchParams, useTransition, useHref, useResolvedPath} from '@remix-run/react'
 import type {Question, QuestionState} from '~/server-utils/stampy'
 
 export const tmpPageId = 999999
@@ -20,10 +20,10 @@ function updateQuestionMap(question: Question, map: Map<Question['pageid'], Ques
   }
 }
 
-export default function useQuestionStateInUrl(initialQuestions: Question[]) {
+export default function useQuestionStateInUrl(noLogo: boolean, initialQuestions: Question[]) {
   const [remixSearchParams] = useSearchParams()
   const transition = useTransition()
-  const noLogo = remixSearchParams.get('noLogo') ? true : false;
+  console.log({href: useHref(''), path: useResolvedPath('')})
 
   const [stateString, setStateString] = useState(() => remixSearchParams.get('state'))
   const [questionMap, setQuestionMap] = useState(() => {

--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -54,8 +54,8 @@ export default function useQuestionStateInUrl(initialQuestions: Question[]) {
 
   useEffect(() => {
     const suffix = stateString ? ` - ${stateString}` : ''
-    document.title = `Stampy (alpha)${suffix}`
-  }, [stateString])
+    document.title = noLogo ? 'AI Safety FAQ' : `Stampy (alpha)${suffix}`
+  }, [stateString, noLogo])
 
   const initialCollapsedState = useMemo(
     () => initialQuestions.map(({pageid}) => `${pageid}-`).join(''),

--- a/app/root.css
+++ b/app/root.css
@@ -85,6 +85,9 @@ header {
   align-items: flex-start;
   padding: 24px 0 48px;
   color: var(--colorTitle);
+}
+
+header.with-logo {
   background-image: url('/assets/coded-banner.svg');
   background-repeat: no-repeat;
   background-attachment: fixed;
@@ -132,10 +135,13 @@ h1 {
   padding: 0 0 10px 30px;
   flex: 0;
   display: flex;
-  flex-direction: column;
   align-items: center;
   gap: 16px;
   transition: opacity 1s;
+}
+
+.with-logo .icon-link-group {
+  flex-direction: column;
 }
 
 .icon-link,

--- a/app/root.css
+++ b/app/root.css
@@ -47,11 +47,6 @@
 html {
   height: 100%;
   overflow-y: scroll;
-  background-image: url('/assets/coded-banner.svg');
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-position: top center;
-  background-size: 800px;
 }
 
 body {
@@ -90,6 +85,11 @@ header {
   align-items: flex-start;
   padding: 24px 0 48px;
   color: var(--colorTitle);
+  background-image: url('/assets/coded-banner.svg');
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: top center;
+  background-size: 800px;
 }
 
 .logo {

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,0 +1,6 @@
+import type {LoaderFunction} from '@remix-run/cloudflare'
+import {redirect} from '@remix-run/cloudflare'
+
+export const loader: LoaderFunction = async ({params}) => {
+  return redirect(`/?${params['*']}`)
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -51,7 +51,7 @@ export default function App() {
 
   return (
     <>
-      <header>
+      <header style={noLogo ? {backgroundImage: 'none'} : {}}>
         {noLogo ? (
           <div className="logo-intro-group">
             <div className="intro">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -14,10 +14,16 @@ import {Share, Users, Code} from '~/components/icons-generated'
 import CopyLink from '~/components/copyLink'
 
 type LoaderData = {
+  noLogo: boolean
   initialQuestions: QuestionType[]
 }
 
 export const loader: LoaderFunction = async ({request}): Promise<LoaderData> => {
+  const isDomainWithLogo = request.url.match(/ui.stampy.ai/)
+  const isLogoForcedOff = request.url.match(/noLogo/)
+  const isLogoForcedOn = request.url.match(/withLogo/)
+  const noLogo = isDomainWithLogo ? !!isLogoForcedOff : !isLogoForcedOn
+
   let initialQuestions: QuestionType[] = []
   try {
     initialQuestions = await loadInitialQuestions(request)
@@ -25,6 +31,7 @@ export const loader: LoaderFunction = async ({request}): Promise<LoaderData> => 
     console.error(e)
   }
   return {
+    noLogo,
     initialQuestions,
   }
 }
@@ -32,16 +39,15 @@ export const loader: LoaderFunction = async ({request}): Promise<LoaderData> => 
 export const unstable_shouldReload: ShouldReloadFunction = () => false
 
 export default function App() {
-  const {initialQuestions} = useLoaderData<LoaderData>()
+  const {noLogo, initialQuestions} = useLoaderData<LoaderData>()
   const {
-    noLogo,
     questions,
     canonicallyAnsweredQuestionsRef,
     reset,
     toggleQuestion,
     onLazyLoadQuestion,
     selectQuestionByTitle,
-  } = useQuestionStateInUrl(initialQuestions)
+  } = useQuestionStateInUrl(noLogo, initialQuestions)
 
   useRerenderOnResize() // recalculate AutoHeight
 
@@ -51,7 +57,7 @@ export default function App() {
 
   return (
     <>
-      <header style={noLogo ? {backgroundImage: 'none'} : {}}>
+      <header className={noLogo ? 'no-logo' : 'with-logo'}>
         {noLogo ? (
           <div className="logo-intro-group">
             <div className="intro">
@@ -79,7 +85,7 @@ export default function App() {
             </div>
           </div>
         )}
-        <div className="icon-link-group" style={noLogo ? {flexDirection: 'row'} : {}}>
+        <div className="icon-link-group">
           <CopyLink>
             <Share />
             Share link

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -79,7 +79,7 @@ export default function App() {
             </div>
           </div>
         )}
-        <div className="icon-link-group">
+        <div className="icon-link-group" style={noLogo ? {flexDirection: 'row'} : {}}>
           <CopyLink>
             <Share />
             Share link


### PR DESCRIPTION
When noLogo=true, the window title is set to "AI Safety FAQ", no colorful background shown, and place top icons in a row to minimize vertical space. As always, LMK if there's a better way to do this.
https://stampy-ui.ccstan99.workers.dev/?noLogo=true
<img width="1099" alt="Screen Shot 2022-09-08 at 1 41 30 PM" src="https://user-images.githubusercontent.com/38997995/189222810-abfcb51d-3a0b-4068-b379-ae91ed82a229.png">
