### PR TITLE
fix GitHub Action to auto generate embeddings

### DIFF
--- a/.github/workflows/gen-encodings-deploy.yml
+++ b/.github/workflows/gen-encodings-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_GEN_EMBEDDINGS }}
           force: true
       - name: Restore stampy-ui repository code
         if: github.event.pull_request.merged == 'true' || steps.check.outputs.changed == 'true'

--- a/questions-encodings.mjs
+++ b/questions-encodings.mjs
@@ -1,6 +1,7 @@
 // server side script called by GitHub Actions to periodically generate encodings stampy.ai wiki questions
 
 // npm install node-fetch @tensorflow/tfjs-node @tensorflow-models/universal-sentence-encoder
+// node questions-encodings.mjs
 import * as tf from '@tensorflow/tfjs-node' // do not remove import, `tf` is needed in following module even if not used in this file
 import * as use from '@tensorflow-models/universal-sentence-encoder'
 import fetch from 'node-fetch'


### PR DESCRIPTION
@plexish @Aprillion I dug around a bit and I *think* the GitHub Actions for generating the embeddings was failing because the script doesn't have permission to push the generated embeddings to the protected main branch. According to (https://github.com/marketplace/actions/push-to-status-check-protected-branches), we might be able to work around this using PAT (personal access tokens). Since I don't have permission to do this, could one of you please:

(1) Create a PAT which grants the following scope/permission with admin write:repo_hook to stampy-ui (https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)

(2) Create a repository secret named "PAT_GEN_EMBEDDINGS" with the value of the PAT from the previous step (https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces)

In this PR, I've updated the GitHub Action to use that new PAT stored under PAT_GEN_EMBEDDINGS. Hopefully, this will work. Otherwise, I found an alternate solution but it felt a bit doesn't look very "clean." Anyway, if all goes well, we set this up to run automatically. 