### PR TITLE
Make sure npm properly globs for older shells

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "scripts": {
     "postinstall": "remix setup cloudflare-workers",
     "generate-icons": "npx @svgr/cli --out-dir app/components/icons-generated -- app/assets/icons",
-    "eslint": "eslint --fix --ignore-pattern .gitignore **/*.ts*",
-    "prettier": "prettier --write --ignore-path .gitignore **/*.{ts*,js,css,md}",
+    "eslint": "eslint --fix --ignore-pattern .gitignore '**/*.ts*'",
+    "prettier": "prettier --write --ignore-path .gitignore '**/*.{ts*,js,css,md}'",
     "lint": "npm run prettier && npm run eslint",
     "build": "rimraf public/build && npm run generate-icons && cross-env NODE_ENV=production remix build",
     "dev:remix": "cross-env NODE_ENV=development remix watch",


### PR DESCRIPTION
'**' was introduced in Bash 4, so older shells treat it as a simple "*". This results in only one level of folders being checked for files. See [this](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784) for more. 