### PR TITLE
Change tooltips to use Tippy instead

### DIFF
--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -4,6 +4,7 @@ import {Question} from '~/routes/questions/$question'
 import {AddQuestion} from '~/routes/questions/add'
 import {MagnifyingGlass} from '~/components/icons-generated'
 import AutoHeight from 'react-auto-height'
+import Tippy from '@tippyjs/react';
 
 type Props = {
   onSiteAnswersRef: MutableRefObject<Question[]>
@@ -156,14 +157,15 @@ const ResultItem = ({
   }`
 
   return (
-    <button
-      className={`transparent-button result-item ${isAlreadyOpen ? 'already-open' : ''}`}
-      key={title}
-      title={tooltip}
-      onClick={() => onSelect(pageid, title)}
-    >
-      {title}
-    </button>
+    <Tippy content={tooltip} theme="search-tooltip">
+      <button
+        className={`transparent-button result-item ${isAlreadyOpen ? 'already-open' : ''}`}
+        key={title}
+        onClick={() => onSelect(pageid, title)}
+      >
+        {title}
+      </button>
+    </Tippy>
   )
 }
 

--- a/app/root.css
+++ b/app/root.css
@@ -499,6 +499,11 @@ footer > *:not(:last-child) {
   background-color: var(--bgColorHighlight);
 }
 
+.tippy-box[data-theme~='search-tooltip'] {
+  background-color: var(--bgColorCopied);
+  color: var(--colorText);
+}
+
 .result-item.already-open {
   color: #999;
   cursor: default;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@remix-run/cloudflare-workers": "^1.6.8",
     "@remix-run/react": "^1.6.8",
+    "@tippyjs/react": "^4.2.6",
     "copy-to-clipboard": "^3.3.2",
     "lodash": "^4.17.21",
     "markdown-it": "^13.0.1",


### PR DESCRIPTION
Implements #51.

This update removes the title tag and instead displays the same information in using Tippy. This was only implemented for the search results.