### PR TITLE
smaller logo for social media preview

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -56,7 +56,7 @@ export const meta: MetaFunction = ({data}) => {
     'og:image:type': 'image/png',
     'og:image:width': '512',
     'og:image:height': '512',
-    'twitter:card': 'summary_large_image',
+    'twitter:card': 'summary',
     'twitter:title': title,
     'twitter:description': description,
     'twitter:image': logo,


### PR DESCRIPTION
Voting in https://discord.com/channels/677546901339504640/758062805810282526/1085884243328114740 - if the last option `D` with image on the side that takes the least amount of vertical space wins, this is the PR for it.

<img src="https://cdn.discordapp.com/attachments/758062805810282526/1085884243105808478/image.png" width=300>