### PR TITLE
Handle dialogs in older browsers

### DIFF
--- a/app/components/dialog.tsx
+++ b/app/components/dialog.tsx
@@ -33,9 +33,22 @@ export default function Dialog({children, onClose}: Props) {
     }
   }
 
-  return (
-    <dialog ref={dialogSetter} className="dialog" onClose={onClose} onClick={closeIfOutside}>
-      <div className="dialog-contents">{children}</div>
-    </dialog>
-  )
+  // Older browsers don't support HTML5 dialogs, so add a fallback option for them
+  const nativeDialogSupport = !!document.createElement('dialog').showModal
+  if (nativeDialogSupport) {
+    return (
+      <dialog ref={dialogSetter} className="dialog" onClose={onClose} onClick={closeIfOutside}>
+        <div className="dialog-contents">{children}</div>
+      </dialog>
+    )
+  } else {
+    return (
+      <div className="dialog">
+        <button className="close" onClick={onClose}>
+          X
+        </button>
+        <div className="dialog-contents">{children}</div>
+      </div>
+    )
+  }
 }

--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -123,7 +123,6 @@ export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions
 
     const onSiteAnswers = onSiteAnswersRef.current
     const onSiteSet = new Set(onSiteAnswers.map(({pageid}) => pageid))
-    console.debug(relatedQuestions, onSiteSet)
 
     return relatedQuestions.filter((question) => {
       const isOnSite = onSiteSet.has(question.pageid)

--- a/app/root.css
+++ b/app/root.css
@@ -586,6 +586,21 @@ footer > *:not(:last-child) {
 .dialog {
   min-width: 30em;
 }
+/* Make sure older browsers work correctly */
+div.dialog {
+  z-index: 100;
+  background-color: var(--bgColorQuestionAnswer);
+  border: 2px solid;
+  padding: 10px;
+  left: 50%;
+  max-width: 90%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+div.dialog .close {
+  position: absolute;
+  right: 10px;
+}
 
 .no-stretch {
   width: 0;


### PR DESCRIPTION
martinkunev#8534 on Discord reported a bug where an older version of firefox breaks when showing tags: https://discord.com/channels/677546901339504640/1088241479639646318
The reason for this bug is that his version of firefox (92) doesn't support HTML5 dialogs. This PR adds a fallback manual dialog thingy:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/3942390/227339966-bf8ce3dc-62c2-46da-9475-26f4fe70d296.png">

It could be made prettier, but I don't think it's worth the bother - most people will have more recent browsers