### PR TITLE
[RFC] Handle relative links to questions

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -6,6 +6,7 @@ import {TOP} from '~/hooks/stateModifiers'
 import useQuestionStateInUrl from '~/hooks/useQuestionStateInUrl'
 import useRerenderOnResize from '~/hooks/useRerenderOnResize'
 import useDraggable from '~/hooks/useDraggable'
+import {getStateEntries} from '~/hooks/stateModifiers'
 import Search from '~/components/search'
 import {Question} from '~/routes/questions/$question'
 import {fetchAnswerDetailsOnSite} from '~/routes/questions/answerDetailsOnSite'
@@ -129,9 +130,15 @@ export default function App() {
       return
     }
 
+    const url = new URL(el.href)
     const href = el.href.replace(/\?.*$/, '')
     const found = onSiteGDocLinkMapRef.current[href]
-    if (found) {
+
+    if (url.hostname === window.location.hostname) {
+      e.preventDefault()
+      const state = new URLSearchParams(url.search).get('state')
+      if (state) selectQuestion(getStateEntries(state)[0][0], '')
+    } else if (found) {
       e.preventDefault()
       selectQuestion(found.pageid, found.title)
     }


### PR DESCRIPTION
https://github.com/StampyAI/stampy-ui/issues/221

This is part of a potential solution.
I was initially considering transforming known gdoc links to relative links in the `stampy.ts` file (or something like that), but it's tricky, as both the list of questions to be displayed and the mapping of gdocs links -> pageids are fetched asynchronously. This means that either can be first, so you'd have to replace links both when the questions are fetched, and when the mapping is fetched. Which quickly gets ugly.

My proposed solution is to move the mapping into the parser. So the markdown will already have gdoc links replaced with the appropriate local links, e.g. `https://docs.google.com/document/d/1gKCatii1pXz53-7djMjP_YrBfvHcNVf0YDtDY1A6A0E/edit` gets transformed to `/?state=1234`. The nice thing about this is that it will work regardless of the domain. The bad thing is that the database value is tied to the presentation layer. This isn't all that much of a problem, in that e.g. discord bots can just replace `/?state=1234` to `https://aisafety.info?state=1234`, but it adds extra fragility to the already fragile system.

The nice thing about this idea is that it will simplify the frontend code, as the gdoc->pageid mapping can be removed (once this PR is tested and the parser gets updated, of course).