### PR TITLE
Log searches to the NLP endpoint

### DIFF
--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -75,7 +75,6 @@ export default function Search({onSiteAnswersRef, openQuestionTitles, onSelect}:
     const value = rawValue.trim()
     if (value === searchInputRef.current) return
 
-    logSearch(value)
     setLoading(true)
     searchInputRef.current = value
 
@@ -94,6 +93,7 @@ export default function Search({onSiteAnswersRef, openQuestionTitles, onSelect}:
       console.debug('postMessage to tfWorker:', value)
       tfWorkerRef.current?.postMessage(value)
     }
+    logSearch(value)
   }
 
   const handleChange = debounce(searchFn, 100)
@@ -404,8 +404,9 @@ const shouldFlushSearch = (value: string, prevSearch: string) => () => {
       body: JSON.stringify({
         name: 'search',
         query: value,
+        type: location.hostname,
       }),
-    }).catch((error) => console.error(error))
+    })
 
   // The searched value is totally different from the previous one - assume that they
   // are searching for something new, and log the previous search value

--- a/app/routes/questions/log.tsx
+++ b/app/routes/questions/log.tsx
@@ -1,8 +1,7 @@
 import type {ActionArgs} from '@remix-run/cloudflare'
 
 export const action = async ({request}: ActionArgs) => {
-  const {query, name} = await request.json()
-  return await fetch(
-    `https://stampy-nlp-t6p37v2uia-uw.a.run.app/api/log_query?name=${name}&type=UI&query=${query}`
-  )
+  const {query, name, type} = await request.json()
+  const url = `${NLP_SEARCH_ENDPOINT}/api/log_query?name=${name}&type=${type}&query=${query}`
+  return await fetch(url)
 }

--- a/app/routes/questions/log.tsx
+++ b/app/routes/questions/log.tsx
@@ -1,0 +1,8 @@
+import type {ActionArgs} from '@remix-run/cloudflare'
+
+export const action = async ({request}: ActionArgs) => {
+  const {query, name} = await request.json()
+  return await fetch(
+    `https://stampy-nlp-t6p37v2uia-uw.a.run.app/api/log_query?name=${name}&type=UI&query=${query}`
+  )
+}


### PR DESCRIPTION
https://github.com/StampyAI/stampy-ui/issues/174

This is quite complicated, as I wanted to only log actual queries, rather than each button press. One way around this would be to only log stuff once the user presses enter, but I'm guessing that would massively limit the number of searches logged. So I settled on this, which amounts to:

* if the current search value is significantly different from the previous one (i.e. neither is a substring of the other), then log the search value
* if the search bar hasn't been changed for the last 4 seconds, log the search term, as the user has probably either found what they were looking for, or have given up