### PR TITLE
Cache invalidation fixes

### DIFF
--- a/app/root.css
+++ b/app/root.css
@@ -698,6 +698,10 @@ a.see-more.visible:after {
   padding-right: 10px;
 }
 
+.cache button {
+  margin: 0 5px;
+}
+
 /* Smaller screen stuff */
 
 @media (max-width: 740px) {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -40,7 +40,7 @@ export default function App() {
 
   const {
     questions,
-    onSiteAnswersRef,
+    onSiteQuestionsRef: onSiteAnswersRef,
     reset,
     toggleQuestion,
     onLazyLoadQuestion,

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,6 @@
 import {useEffect, MouseEvent, useRef} from 'react'
 import type {LoaderFunction} from '@remix-run/cloudflare'
-import {ShouldReloadFunction, useOutletContext, useLoaderData} from '@remix-run/react'
+import {ShouldRevalidateFunction, useOutletContext, useLoaderData} from '@remix-run/react'
 import {loadInitialQuestions, QuestionState} from '~/server-utils/stampy'
 import {TOP} from '~/hooks/stateModifiers'
 import useQuestionStateInUrl from '~/hooks/useQuestionStateInUrl'
@@ -25,7 +25,7 @@ export const loader = async ({request}: Parameters<LoaderFunction>[0]) => {
   }
 }
 
-export const unstable_shouldReload: ShouldReloadFunction = () => false
+export const shouldRevalidate: ShouldRevalidateFunction = () => false
 
 export default function App() {
   const minLogo = useOutletContext<boolean>()

--- a/app/routes/questions/$question.tsx
+++ b/app/routes/questions/$question.tsx
@@ -1,4 +1,4 @@
-import type {LoaderFunction} from '@remix-run/cloudflare'
+import type {LoaderArgs} from '@remix-run/cloudflare'
 import {GlossaryEntry, loadQuestionDetail, QuestionStatus} from '~/server-utils/stampy'
 import {useRef, useEffect, useState} from 'react'
 import AutoHeight from 'react-auto-height'
@@ -12,7 +12,7 @@ import {reloadInBackgroundIfNeeded} from '~/server-utils/kv-cache'
 
 const UNKNOWN_QUESTION_TITLE = 'Unknown question'
 
-export const loader = async ({request, params}: Parameters<LoaderFunction>[0]) => {
+export const loader = async ({request, params}: LoaderArgs) => {
   const {question} = params
   if (!question) {
     throw Error('missing question title')

--- a/app/routes/questions/allQuestionsOnSite.ts
+++ b/app/routes/questions/allQuestionsOnSite.ts
@@ -1,8 +1,8 @@
-import {LoaderFunction} from '@remix-run/cloudflare'
+import {LoaderArgs} from '@remix-run/cloudflare'
 import {reloadInBackgroundIfNeeded} from '~/server-utils/kv-cache'
 import {loadAllQuestions} from '~/server-utils/stampy'
 
-export const loader: LoaderFunction = async ({request}) => {
+export const loader = async ({request}: LoaderArgs) => {
   return await loadAllQuestions(request)
 }
 

--- a/app/routes/questions/allQuestionsOnSite.ts
+++ b/app/routes/questions/allQuestionsOnSite.ts
@@ -5,13 +5,17 @@ import {loadAllQuestions} from '~/server-utils/stampy'
 export const loader = async ({request}: LoaderArgs) => {
   return await loadAllQuestions(request)
 }
+type Data = ReturnType<typeof loader>
 
 export function fetchAllQuestionsOnSite() {
   const url = `/questions/allQuestionsOnSite`
   return fetch(url).then(async (response) => {
-    const {data, timestamp}: Awaited<ReturnType<typeof loader>> = await response.json()
-    reloadInBackgroundIfNeeded(url, timestamp)
+    const {data, timestamp}: Awaited<Data> = await response.json()
+    const backgroundPromiseIfReloaded: Data | Promise<void> = reloadInBackgroundIfNeeded(
+      url,
+      timestamp
+    )
 
-    return data
+    return {data, backgroundPromiseIfReloaded}
   })
 }

--- a/app/routes/questions/allQuestionsOnSite.ts
+++ b/app/routes/questions/allQuestionsOnSite.ts
@@ -1,8 +1,9 @@
+import {LoaderFunction} from '@remix-run/cloudflare'
 import {reloadInBackgroundIfNeeded} from '~/server-utils/kv-cache'
 import {loadAllQuestions} from '~/server-utils/stampy'
 
-export const loader = async () => {
-  return await loadAllQuestions()
+export const loader: LoaderFunction = async ({request}) => {
+  return await loadAllQuestions(request)
 }
 
 export function fetchAllQuestionsOnSite() {

--- a/app/routes/questions/answerDetailsOnSite.ts
+++ b/app/routes/questions/answerDetailsOnSite.ts
@@ -1,8 +1,8 @@
-import type {LoaderFunction} from '@remix-run/cloudflare'
+import type {LoaderArgs} from '@remix-run/cloudflare'
 import {reloadInBackgroundIfNeeded} from '~/server-utils/kv-cache'
 import {loadOnSiteAnswers, loadMoreAnswerDetails} from '~/server-utils/stampy'
 
-export const loader = async ({request}: Parameters<LoaderFunction>[0]) => {
+export const loader = async ({request}: LoaderArgs) => {
   const searchParams = new URL(request.url).searchParams
   const nextPage = searchParams.get('nextPage')
   if (nextPage !== null) {

--- a/app/routes/questions/cache.tsx
+++ b/app/routes/questions/cache.tsx
@@ -1,17 +1,74 @@
-import {useLoaderData, Form} from '@remix-run/react'
-import {loadCache, cleanCache} from '~/server-utils/kv-cache'
+import {ActionArgs, json} from '@remix-run/cloudflare'
+import {useLoaderData, useActionData, useTransition, Form} from '@remix-run/react'
+import {useEffect, useState} from 'react'
+import {loadCacheKeys, loadCacheValue, cleanCache} from '~/server-utils/kv-cache'
 
-export const loader = async () => await loadCache()
+enum Actions {
+  delete = 'delete',
+  reload = 'reload',
+  loadCache = 'loadCache',
+}
 
-export const action = async () => await cleanCache()
+export const loader = async () => await loadCacheKeys()
+
+export const action = async ({request}: ActionArgs) => {
+  const data = Array.from(await request.formData()) as [Actions, string][]
+  if (data.length !== 1) {
+    return json(
+      {error: `Expected only 1 formData key-value pair, got ${JSON.stringify(data)}`},
+      {status: 400}
+    )
+  }
+  const [actionKey, cacheKey] = data[0]
+  if (actionKey === Actions.delete) {
+    return cleanCache(cacheKey)
+  } else if (actionKey === Actions.loadCache) {
+    return json({cacheKey, cacheValue: await loadCacheValue(cacheKey)})
+  } else if (actionKey === Actions.reload) {
+    return null
+  } else {
+    return json({error: `Unknown action ${actionKey}`}, {status: 400})
+  }
+}
 
 export default function Cache() {
-  const data = useLoaderData()
+  const keys = useLoaderData<typeof loader>()
+  const actionData = useActionData<typeof action>()
+  const transition = useTransition()
+  // @ts-expect-error inferred type kinda looks OK, but TS is unhappy anyway
+  const {error, cacheKey, cacheValue} = actionData ?? {}
+  const [cacheValues, setCacheValues] = useState(() =>
+    Object.fromEntries(keys.map((k) => [k, null]))
+  )
+  useEffect(() => {
+    if (cacheKey) {
+      setCacheValues((curr) => ({
+        ...curr,
+        [cacheKey]: cacheValue,
+      }))
+    }
+  }, [cacheKey, cacheValue])
 
   return (
-    <Form method="post">
-      <button>Clean cache</button>
-      <pre>{JSON.stringify(data, null, 2)}</pre>
+    <Form method="post" className="cache">
+      <h1>Cached data</h1>
+      <button name={Actions.delete}>Clean cache</button>
+      <button name={Actions.reload}>Reload keys</button>
+      {transition.type !== 'idle' && transition.type}
+      {error && <div className="error">{error}</div>}
+      <h2>Keys:</h2>
+      <ul>
+        {keys.length === 0 && <i>(the cache is empty)</i>}
+        {keys.map((key) => (
+          <li key={key}>
+            {key}
+            <button name={Actions.loadCache} value={key}>
+              {cacheValues[key] ? 'Reload' : 'Show'} value
+            </button>
+            {cacheValues[key] && <pre>{cacheValues[key]}</pre>}
+          </li>
+        ))}
+      </ul>
     </Form>
   )
 }

--- a/app/routes/questions/glossary.ts
+++ b/app/routes/questions/glossary.ts
@@ -1,8 +1,9 @@
+import {LoaderFunction} from '@remix-run/cloudflare'
 import {reloadInBackgroundIfNeeded} from '~/server-utils/kv-cache'
 import {loadGlossary} from '~/server-utils/stampy'
 
-export const loader = async () => {
-  return await loadGlossary()
+export const loader: LoaderFunction = async ({request}) => {
+  return await loadGlossary(request)
 }
 
 export function fetchGlossary() {

--- a/app/routes/questions/glossary.ts
+++ b/app/routes/questions/glossary.ts
@@ -1,8 +1,8 @@
-import {LoaderFunction} from '@remix-run/cloudflare'
+import {LoaderArgs} from '@remix-run/cloudflare'
 import {reloadInBackgroundIfNeeded} from '~/server-utils/kv-cache'
 import {loadGlossary} from '~/server-utils/stampy'
 
-export const loader: LoaderFunction = async ({request}) => {
+export const loader = async ({request}: LoaderArgs) => {
   return await loadGlossary(request)
 }
 

--- a/app/routes/questions/glossary.ts
+++ b/app/routes/questions/glossary.ts
@@ -5,13 +5,17 @@ import {loadGlossary} from '~/server-utils/stampy'
 export const loader = async ({request}: LoaderArgs) => {
   return await loadGlossary(request)
 }
+type Data = ReturnType<typeof loader>
 
 export function fetchGlossary() {
   const url = `/questions/glossary`
   return fetch(url).then(async (response) => {
-    const {data, timestamp}: Awaited<ReturnType<typeof loader>> = await response.json()
-    reloadInBackgroundIfNeeded(url, timestamp)
+    const {data, timestamp}: Awaited<Data> = await response.json()
+    const backgroundPromiseIfReloaded: Data | Promise<void> = reloadInBackgroundIfNeeded(
+      url,
+      timestamp
+    )
 
-    return data
+    return {data, backgroundPromiseIfReloaded}
   })
 }

--- a/app/routes/questions/search.tsx
+++ b/app/routes/questions/search.tsx
@@ -1,6 +1,6 @@
-import type {LoaderFunction} from '@remix-run/cloudflare'
+import type {LoaderArgs} from '@remix-run/cloudflare'
 
-export const loader = async ({request}: Parameters<LoaderFunction>[0]) => {
+export const loader = async ({request}: LoaderArgs) => {
   const url = new URL(request.url)
   const question = url.searchParams.get('question')
   const onlyLive = url.searchParams.get('onlyLive') == 'true'

--- a/app/server-utils/kv-cache.ts
+++ b/app/server-utils/kv-cache.ts
@@ -39,7 +39,13 @@ export async function reloadInBackgroundIfNeeded(url: string, timestamp: string)
   // TODO: #228 keep debug for a few day after fixing cache invalidation, can be deleted later
   console.debug('Reload needed', ageInMilliseconds > 10 * 60 * 1000, url || '/', timestamp)
   if (ageInMilliseconds > 10 * 60 * 1000) {
-    fetch(`${url}${url.includes('?') ? '&' : '?'}reload`)
+    const text = await(await fetch(`${url}${url.includes('?') ? '&' : '?'}reload`)).text()
+    try {
+      const json = JSON.parse(text)
+      return json
+    } catch (e) {
+      return text
+    }
   }
 }
 

--- a/app/server-utils/stampy.ts
+++ b/app/server-utils/stampy.ts
@@ -324,7 +324,7 @@ const toTag = (r: CodaRow, nameToId: Record<string, string>): Tag => ({
 export const loadTag = withCache('tag', async (tagName: string): Promise<Tag> => {
   const rows = await getCodaRows(TAGS_TABLE, 'Tag name', tagName)
 
-  const questions = await loadAllQuestions()
+  const questions = await loadAllQuestions('NEVER_RELOAD')
   const nameToId = Object.fromEntries(
     questions.data
       .filter((q) => q.status == QuestionStatus.LIVE_ON_SITE)
@@ -336,7 +336,7 @@ export const loadTag = withCache('tag', async (tagName: string): Promise<Tag> =>
 export const loadTags = withCache('tags', async (): Promise<Tag[]> => {
   const rows = await getCodaRows(TAGS_TABLE, 'Internal?', 'false')
 
-  const questions = await loadAllQuestions()
+  const questions = await loadAllQuestions('NEVER_RELOAD')
   const nameToId = Object.fromEntries(
     questions.data
       .filter((q) => q.status == QuestionStatus.LIVE_ON_SITE)


### PR DESCRIPTION
Fixing #228 by passing `request` object to `withCache` so it's able to send `?reload` request.

Also improving the cache page (faster loading of page, showing only keys without values initially), see deployed on https://stampy-ui.aprillion.workers.dev/questions/cache.
![image](https://github.com/StampyAI/stampy-ui/assets/1087670/70d70580-b707-45f7-8377-0fc9eaab515f)


And using data loaded in background where it makes sense (only for lazy features that wouldn't cause jumping of initial questions), so the current user benefits form the background data refresh too 😅 