### PR TITLE
Make links out of search results and question titles when embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Contributions are welcome, the code is released under the MIT License. If you'd 
   - placeholder (string) - override `<input placeholder=...>` of the search box
   - theme (light|dark) - override CSS theme (if not provided, the embedded site will use `preferred-color-scheme` system setting)
   - showInitial - also show initial questions, not just search bar
+  - showDetails - open question details (answers) directly instead of just links to aisafety.info
 - more (disabled|infini|button|buttonInfini) - debug versions of load more / infinite scroll, e.g. `aisafety.info/?more=infini`
 
 ## Stampy UI Development Setup

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -12,11 +12,17 @@ type Props = {
   onSiteAnswersRef: MutableRefObject<QuestionType[]>
   openQuestionTitles: string[]
   onSelect: (pageid: string, title: string) => void
+  embedWithoutDetails?: boolean
 }
 
 const empty: [] = []
 
-export default function Search({onSiteAnswersRef, openQuestionTitles, onSelect}: Props) {
+export default function Search({
+  onSiteAnswersRef,
+  openQuestionTitles,
+  onSelect,
+  embedWithoutDetails,
+}: Props) {
   const [showResults, setShowResults] = useState(false)
   const [showMore, setShowMore] = useState(false)
   const searchInputRef = useRef('')
@@ -95,6 +101,7 @@ export default function Search({onSiteAnswersRef, openQuestionTitles, onSelect}:
                       onSelect: handleSelect,
                       isAlreadyOpen: openQuestionTitles.includes(title),
                       setHide,
+                      embedWithoutDetails,
                     }}
                   />
                 ))}
@@ -133,6 +140,7 @@ const ResultItem = ({
   onSelect,
   isAlreadyOpen,
   setHide,
+  embedWithoutDetails,
 }: {
   pageid: string
   title: string
@@ -141,7 +149,21 @@ const ResultItem = ({
   onSelect: Props['onSelect']
   isAlreadyOpen: boolean
   setHide?: (b: boolean) => void
+  embedWithoutDetails?: boolean
 }) => {
+  if (embedWithoutDetails) {
+    return (
+      <a
+        href={`https://aisafety.info/?state=${pageid}_`}
+        className="transparent-link result-item result-item-box"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {title}
+      </a>
+    )
+  }
+
   const tooltip = `score: ${score.toFixed(2)}, engine: ${model} ${
     isAlreadyOpen ? '(already open)' : ''
   }`

--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -36,6 +36,8 @@ const emptyQuestionArray: Question[] = []
 export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions: Question[]) {
   const [remixSearchParams] = useSearchParams()
   const transition = useTransition()
+  const embedWithoutDetails =
+    remixSearchParams.has('embed') && !remixSearchParams.has('showDetails')
 
   const [stateString, setStateString] = useState(
     () =>
@@ -194,6 +196,12 @@ export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions
   const toggleQuestion = useCallback(
     (questionProps: Question, options?: {moveToTop?: boolean; onlyRelated?: boolean}) => {
       const {pageid, relatedQuestions} = questionProps
+
+      if (embedWithoutDetails) {
+        window.open(`https://aisafety.info/?state=${pageid}_`, '_blank')
+        return
+      }
+
       let currentState = stateString ?? initialCollapsedState
 
       if (options?.moveToTop) {
@@ -214,7 +222,7 @@ export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions
 
       updateStateString(newState)
     },
-    [initialCollapsedState, questions, stateString, updateStateString]
+    [initialCollapsedState, questions, stateString, updateStateString, embedWithoutDetails]
   )
 
   const onLazyLoadQuestion = useCallback(

--- a/app/hooks/useQuestionStateInUrl.ts
+++ b/app/hooks/useQuestionStateInUrl.ts
@@ -197,11 +197,6 @@ export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions
     (questionProps: Question, options?: {moveToTop?: boolean; onlyRelated?: boolean}) => {
       const {pageid, relatedQuestions} = questionProps
 
-      if (embedWithoutDetails) {
-        window.open(`https://aisafety.info/?state=${pageid}_`, '_blank')
-        return
-      }
-
       let currentState = stateString ?? initialCollapsedState
 
       if (options?.moveToTop) {
@@ -222,7 +217,7 @@ export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions
 
       updateStateString(newState)
     },
-    [initialCollapsedState, questions, stateString, updateStateString, embedWithoutDetails]
+    [initialCollapsedState, questions, stateString, updateStateString]
   )
 
   const onLazyLoadQuestion = useCallback(
@@ -298,5 +293,6 @@ export default function useQuestionStateInUrl(minLogo: boolean, initialQuestions
     addQuestions,
     moveQuestion,
     glossary,
+    embedWithoutDetails,
   }
 }

--- a/app/root.css
+++ b/app/root.css
@@ -104,6 +104,11 @@ a:hover,
   cursor: pointer;
 }
 
+a.transparent-link {
+  width: 100%;
+  color: inherit;
+}
+
 /* reset default styles if user prefers light/dark mode, but chooses dark/light mode in the toggle */
 input,
 textarea,
@@ -297,11 +302,14 @@ article > h2 {
   font-size: clamp(1rem, 2vw, 1.2rem);
   font-weight: 400;
   line-height: 1.2;
-  cursor: pointer;
   display: flex;
   justify-content: space-between;
   align-items: center;
   border-radius: 2px;
+}
+
+article > h2 > .chevron {
+  cursor: pointer;
 }
 
 article > h2 > .transparent-button {
@@ -319,7 +327,7 @@ article > h2:not(:hover) > .transparent-button svg {
   opacity: 0;
 }
 
-article > h2::after {
+article > h2.chevron::after {
   content: url('/assets/chevron-right.svg');
   width: 12px;
   height: 12px;
@@ -331,7 +339,7 @@ article:not(.link-hovered) > h2:hover::after {
   transform: rotate(20deg);
 }
 
-article.expanded h2::after {
+article.expanded h2.chevron::after {
   transform: translateY(3px) rotate(90deg);
 }
 
@@ -696,7 +704,7 @@ a:focus-visible,
   border-radius: 2px;
 }
 
-a.see-more:not(.visible) + div.see-more-contents {
+transparent-buttonsee-more:not(.visible) + div.see-more-contents {
   display: none;
 }
 a.see-more:after {
@@ -706,7 +714,7 @@ a.see-more.visible:after {
   content: 'See less';
 }
 
-a[target='_blank']:not(.icon-link):after {
+a[target='_blank']:not(.icon-link, .transparent-link):after {
   content: ' ';
   display: inline-block;
   vertical-align: top;

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -124,6 +124,7 @@ export default function App() {
     addQuestions,
     moveQuestion,
     glossary,
+    embedWithoutDetails,
   } = useQuestionStateInUrl(minLogo, initialQuestions)
 
   const openQuestionTitles = questions
@@ -190,6 +191,7 @@ export default function App() {
           onSiteAnswersRef={onSiteAnswersRef}
           openQuestionTitles={openQuestionTitles}
           onSelect={selectQuestion}
+          embedWithoutDetails={embedWithoutDetails}
         />
 
         {/* Add an extra, draggable div here, so that questions can be moved to the top of the list */}
@@ -210,6 +212,7 @@ export default function App() {
                 onDragEnd={handleDragEnd(question)}
                 onDragOver={handleDragOver(question)}
                 draggable
+                embedWithoutDetails={embedWithoutDetails}
               />
               <DragPlaceholder pageid={question.pageid} />
             </ErrorBoundary>

--- a/app/routes/questions/$question.tsx
+++ b/app/routes/questions/$question.tsx
@@ -59,6 +59,7 @@ export function Question({
   onToggle,
   selectQuestion,
   glossary,
+  embedWithoutDetails,
   ...dragProps
 }: {
   questionProps: Question
@@ -66,6 +67,7 @@ export function Question({
   onToggle: ReturnType<typeof useQuestionStateInUrl>['toggleQuestion']
   glossary: Glossary
   selectQuestion: (pageid: string, title: string) => void
+  embedWithoutDetails?: boolean
 } & JSX.IntrinsicElements['div']) {
   const {pageid, title, text, answerEditLink, questionState, tags, banners} = questionProps
   const isLoading = useRef(false)
@@ -94,6 +96,23 @@ export function Question({
     onToggle(questionProps)
   }
 
+  if (embedWithoutDetails) {
+    return (
+      <article className={cls}>
+        <h2>
+          <a
+            href={`https://aisafety.info/?state=${pageid}_`}
+            className="transparent-link"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {title}
+          </a>
+        </h2>
+      </article>
+    )
+  }
+
   let html
   if (text == '') {
     html = `<i>We don't have an answer for this question yet. Would you like to <a href="${answerEditLink}">write one</a>?</a>`
@@ -105,7 +124,12 @@ export function Question({
 
   return (
     <article className={cls}>
-      <h2 onClick={handleToggle} title={isExpanded ? 'Hide answer' : 'Show answer'} {...dragProps}>
+      <h2
+        onClick={handleToggle}
+        className="chevron"
+        title={isExpanded ? 'Hide answer' : 'Show answer'}
+        {...dragProps}
+      >
         <button className="transparent-button">
           {title}
           <CopyLink

--- a/public/embed-example.html
+++ b/public/embed-example.html
@@ -16,7 +16,9 @@
   'use strict'
   const iframe = document.getElementById('ai-safety-search-iframe')
   const iframeWindow = iframe.contentWindow
-  iframeWindow.addEventListener('focus', () => {
-    iframe.style.height = '100vh'
-  })
+  const expand = () => {
+    iframe.style.height = '600px'
+    iframeWindow.removeEventListener('keydown', expand)
+  }
+  iframeWindow.addEventListener('keydown', expand)
 </script>


### PR DESCRIPTION
Improvements for #307 => testing on https://aisafety.preview.softr.app/new
* can be controlled by `showDetails` url param
* I was not able to reproduce dynamic height in Softr, either CSP or it doesn't allow listening to events somehow, so this is a version more friendly for static height