### PR TITLE
Support shareable url with search query (q and limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Contributions are welcome, the code is released under the MIT License. If you'd 
 
 ## Supported URL parameters
 
-- state - controls which questions are displayed as collapsed / open / related, e.g. `aisafety.info/?state=6568_897Ir6220r`
-- embed - show site without header/footer for embedding on other sites, e.g. [embed-example.html](/public/embed-example.html)
+- state - controls which questions are displayed as collapsed / open / related, e.g. [aisafety.info/?state=6568\_](https://aisafety.info/?state=6568_)
+- q (string) - search query for sharing direct link to search results (and not just link to 1 question), e.g. [aisafety.info/?q=alignment&limit=10](https://aisafety.info/?q=alignment&limit=10)
+  - limit (number, default 5) - how many results to show
+- embed - show site without header/footer for embedding on other sites, se [embed-example.html](/public/embed-example.html)
   - placeholder (string) - override `<input placeholder=...>` of the search box
   - theme (light|dark) - override CSS theme (if not provided, the embedded site will use `preferred-color-scheme` system setting)
   - showInitial - also show initial questions, not just search bar

--- a/app/components/layouts.tsx
+++ b/app/components/layouts.tsx
@@ -1,4 +1,3 @@
-import {MouseEvent} from 'react'
 import {useOutletContext, Link} from '@remix-run/react'
 import logoFunSvg from '../assets/stampy-logo.svg'
 import logoMinSvg from '../assets/stampy-logo-min.svg'
@@ -8,7 +7,7 @@ import type {Context} from '~/root'
 
 const year = new Date().getFullYear()
 
-export const Header = ({reset = () => null}: {reset?: (e: MouseEvent) => void}) => {
+export const Header = () => {
   const {minLogo, embed} = useOutletContext<Context>()
 
   if (embed) return null
@@ -16,9 +15,9 @@ export const Header = ({reset = () => null}: {reset?: (e: MouseEvent) => void}) 
   return (
     <header className={minLogo ? 'min-logo' : 'fun-logo'}>
       <div className="logo-intro-group">
-        <Link to="/" onClick={(e) => reset(e)}>
+        <a href="/">
           <img className="logo" alt="logo" src={minLogo ? logoMinSvg : logoFunSvg} />
-        </Link>
+        </a>
         <div className="intro">
           {minLogo ? (
             <>

--- a/app/root.css
+++ b/app/root.css
@@ -157,12 +157,14 @@ header.fun-logo {
 .fun-logo .logo {
   height: clamp(100px, 20vw, 150px);
   width: auto;
+  aspect-ratio: 150 / 129;
   padding: clamp(1rem, 5vw, 2rem) 24px 0 16px;
 }
 
 .min-logo .logo {
   height: clamp(50px, 15vw, 100px);
   width: auto;
+  aspect-ratio: 79 / 68;
   padding: clamp(1rem, 5vw, 2rem) 12px 0 0;
 }
 

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -59,6 +59,8 @@ const Bottom = ({
   const urlLoadType = useCallback(() => {
     const more = remixSearchParams.get('more')
     if (more) return LoadMoreType[remixSearchParams.get('more') as keyof typeof LoadMoreType]
+    const queryFromUrl = remixSearchParams.get('q')
+    if (queryFromUrl) return LoadMoreType.disabled
   }, [remixSearchParams])
 
   const [loadMore, setLoadMore] = useState(
@@ -227,17 +229,17 @@ export default function App() {
         </div>
       </main>
       {!embed && (
-        <a id="discordChatBtn" href="https://discord.com/invite/Bt8PaRTDQC">
-          <Discord />
-        </a>
-      )}
-      {!embed && !queryFromUrl && (
-        <Bottom
-          fetchMore={fetchMoreQuestions}
-          isSingleQuestion={
-            questions.filter((i) => i.questionState != QuestionState.RELATED).length == 1
-          }
-        />
+        <>
+          <a id="discordChatBtn" href="https://discord.com/invite/Bt8PaRTDQC">
+            <Discord />
+          </a>
+          <Bottom
+            fetchMore={fetchMoreQuestions}
+            isSingleQuestion={
+              questions.filter((i) => i.questionState != QuestionState.RELATED).length == 1
+            }
+          />
+        </>
       )}
     </>
   )

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -23,11 +23,11 @@ import type {Context} from '~/root'
 
 const empty: Awaited<ReturnType<typeof loadInitialQuestions>> = {data: [], timestamp: ''}
 export const loader = async ({request}: Parameters<LoaderFunction>[0]) => {
-  const embed = !!request.url.match(/embed/)
+  const showInitialFromUrl = !!request.url.match(/showInitial/)
+  const embedFromUrl = !!request.url.match(/embed/)
   const queryFromUrl = !!request.url.match(/[?&]q=/)
-  const showInitial = !!request.url.match(/showInitial/)
-  const hideInitial = (embed || queryFromUrl) && !showInitial
-  if (hideInitial) return {initialQuestionsData: empty}
+  const fetchInitial = showInitialFromUrl || (!embedFromUrl && !queryFromUrl)
+  if (!fetchInitial) return {initialQuestionsData: empty}
 
   try {
     await loadTags(request)

--- a/public/tfWorker.js
+++ b/public/tfWorker.js
@@ -34,9 +34,7 @@ self.onmessage = (e) => {
 }
 
 const maxAttempts = 10
-const runSemanticSearch = (userQuery, attempt = 1) => {
-  numResults = 5
-
+const runSemanticSearch = ({userQuery, numResults}, attempt = 1) => {
   if (!userQuery || attempt >= maxAttempts) {
     return
   }
@@ -62,6 +60,7 @@ const runSemanticSearch = (userQuery, attempt = 1) => {
       title,
       pageid: pageids[index],
       score: scores[index],
+      model: '@tensorflow-models/universal-sentence-encoder',
     }))
     questionsScored.sort(byScore)
     const seen = new Set()


### PR DESCRIPTION
Replacing feature from #303 to be able to share url to search results instead of just directly to answer.

Some fixes for URL state when overwriting search and using the browser back/forward buttons, seems good enough for this hidden feature, but probably not 100% bugfree yet 😅 

Testable in https://stampy-ui.aprillion.workers.dev/?q=why&limit=100