### PR TITLE
fix glossary popup styles

### DIFF
--- a/app/root.css
+++ b/app/root.css
@@ -29,7 +29,7 @@
   --colorButtonText: #c97;
   --paddingSides: clamp(8px, 2vw, 16px);
   --marginTags: clamp(5px, 1vw, 10px);
-  --baseFont: normal 400 1rem "Open Sans", Arial, sans-serif;
+  --baseFont: normal 400 1rem 'Open Sans', Arial, sans-serif;
 
   /* dark theme at the end of file to overwrite all previous rules */
 }
@@ -437,7 +437,7 @@ tr:nth-child(even) {
   margin-left: 10px;
   max-width: 35%;
   z-index: 2;
-  transition: visibility 0s 300ms, opacity cubic-bezier(1,0,1,1) 300ms;
+  transition: visibility 0s 300ms, opacity cubic-bezier(1, 0, 1, 1) 300ms;
 }
 .answer .link-popup::after {
   content: '';

--- a/app/root.css
+++ b/app/root.css
@@ -29,6 +29,7 @@
   --colorButtonText: #c97;
   --paddingSides: clamp(8px, 2vw, 16px);
   --marginTags: clamp(5px, 1vw, 10px);
+  --baseFont: normal 400 1rem "Open Sans", Arial, sans-serif;
 
   /* dark theme at the end of file to overwrite all previous rules */
 }
@@ -79,7 +80,7 @@ body {
   color: var(--colorText);
   display: flex;
   flex-direction: column;
-  font-family: 'Open Sans', Arial, sans-serif;
+  font: var(--baseFont);
   line-height: 1.5;
 }
 
@@ -425,14 +426,18 @@ tr:nth-child(even) {
 
 .answer .link-popup {
   visibility: hidden;
+  opacity: 0;
   position: absolute;
   display: inline-block;
   border-radius: 5px;
   background: var(--colorTooltip);
+  color: var(--colorText);
+  font: var(--baseFont);
   padding: 5px 10px;
   margin-left: 10px;
   max-width: 35%;
   z-index: 2;
+  transition: visibility 0s 300ms, opacity cubic-bezier(1,0,1,1) 300ms;
 }
 .answer .link-popup::after {
   content: '';
@@ -446,6 +451,9 @@ tr:nth-child(even) {
 
 .answer .link-popup.shown {
   visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  transition: visibility 0s, opacity 100ms;
 }
 .answer .link-popup p {
   margin: 0;


### PR DESCRIPTION
* use transition to keep hover while moving the mouse diagonally through margin
* reset color and font overriding inherited values from parent link
* https://stampy-ui.aprillion.workers.dev/