### PR TITLE
Fix manual dispatch of deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ env:
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Clone stampy-ui repository code


### PR DESCRIPTION
* actions after merging PRs from forked repos don't have access to GH secrets and fail => manual deploy is needed for those
* tested in https://github.com/StampyAI/stampy-ui/actions/runs/6423175192