### PR TITLE
feat(refresh-coda-cache workflow): add workflow.

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,5 +18,4 @@ jobs:
       - name: test
         run: |
           cp wrangler.toml.template wrangler.toml
-          npm run refresh-test-data
           npm run test


### PR DESCRIPTION
Removes the refresh of the coda data from the `pr-check` workflow, so that workflow can run from forked branches. Fixing #353 . 

Related to this PR, PR #356 adds a workflow to make is easier to refresh the cached data. 