### PR TITLE
pin @node/types to 20.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@types/lodash": "^4.14.202",
         "@types/markdown-it": "^13.0.7",
         "@types/markdown-it-footnote": "^3.0.3",
-        "@types/node": "20.8.3",
         "@types/react": "^18.2.53",
         "@types/react-dom": "^18.2.18",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -6839,6 +6838,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/@storybook/core-common/node_modules/@types/node": {
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@storybook/core-common/node_modules/esbuild": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -6975,6 +6983,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@types/node": {
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@storybook/core-server/node_modules/fs-extra": {
@@ -7365,6 +7382,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
+    },
+    "node_modules/@storybook/react/node_modules/@types/node": {
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@storybook/react/node_modules/acorn": {
       "version": "7.4.1",
@@ -21468,6 +21494,12 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -25558,7 +25590,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "jest-message-util": "^29.7.0",
         "jest-util": "^29.7.0",
@@ -25576,7 +25608,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -25609,7 +25641,7 @@
       "requires": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "jest-mock": "^29.7.0"
       }
     },
@@ -25640,7 +25672,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "jest-message-util": "^29.7.0",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
@@ -25670,7 +25702,7 @@
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -25801,7 +25833,7 @@
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       }
@@ -27105,7 +27137,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "20.8.3",
+            "@types/node": "*",
             "@types/yargs": "^16.0.0",
             "chalk": "^4.0.0"
           }
@@ -27126,7 +27158,7 @@
           "dev": true,
           "requires": {
             "@jest/types": "^27.5.1",
-            "@types/node": "20.8.3"
+            "@types/node": "*"
           }
         }
       }
@@ -27676,7 +27708,7 @@
         "@storybook/node-logger": "7.6.12",
         "@storybook/types": "7.6.12",
         "@types/find-cache-dir": "^3.2.1",
-        "@types/node": "20.8.3",
+        "@types/node": "^18.0.0",
         "@types/node-fetch": "^2.6.4",
         "@types/pretty-hrtime": "^1.0.0",
         "chalk": "^4.1.0",
@@ -27851,6 +27883,15 @@
           "dev": true,
           "optional": true
         },
+        "@types/node": {
+          "version": "18.19.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+          "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "esbuild": {
           "version": "0.18.20",
           "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -27940,7 +27981,7 @@
         "@storybook/telemetry": "7.6.12",
         "@storybook/types": "7.6.12",
         "@types/detect-port": "^1.3.0",
-        "@types/node": "20.8.3",
+        "@types/node": "^18.0.0",
         "@types/pretty-hrtime": "^1.0.0",
         "@types/semver": "^7.3.4",
         "better-opn": "^3.0.2",
@@ -27967,6 +28008,15 @@
         "ws": "^8.2.3"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.19.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+          "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "fs-extra": {
           "version": "11.2.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -28175,7 +28225,7 @@
         "@storybook/types": "7.6.12",
         "@types/escodegen": "^0.0.6",
         "@types/estree": "^0.0.51",
-        "@types/node": "20.8.3",
+        "@types/node": "^18.0.0",
         "acorn": "^7.4.1",
         "acorn-jsx": "^5.3.1",
         "acorn-walk": "^7.2.0",
@@ -28194,6 +28244,15 @@
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
           "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.19.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+          "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "acorn": {
           "version": "7.4.1",
@@ -28708,7 +28767,7 @@
       "integrity": "sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/body-parser": {
@@ -28718,7 +28777,7 @@
       "dev": true,
       "requires": {
         "@types/connect": "*",
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/chai": {
@@ -28733,7 +28792,7 @@
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/cookie": {
@@ -28747,7 +28806,7 @@
       "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/debug": {
@@ -28822,7 +28881,7 @@
       "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
@@ -28841,7 +28900,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/graceful-fs": {
@@ -28850,7 +28909,7 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/hast": {
@@ -28996,7 +29055,7 @@
       "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "form-data": "^4.0.0"
       }
     },
@@ -29006,7 +29065,7 @@
       "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/normalize-package-data": {
@@ -29084,7 +29143,7 @@
       "dev": true,
       "requires": {
         "@types/mime": "^1",
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/serve-static": {
@@ -29095,7 +29154,7 @@
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",
-        "@types/node": "20.8.3"
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -31860,7 +31919,7 @@
       "integrity": "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "require-like": ">= 0.1.1"
       }
     },
@@ -33463,7 +33522,7 @@
         "@jest/expect": "^29.7.0",
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^1.0.0",
@@ -33625,7 +33684,7 @@
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
       }
@@ -33644,7 +33703,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
@@ -33702,7 +33761,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "jest-util": "^29.7.0"
       }
     },
@@ -33770,7 +33829,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
@@ -33819,7 +33878,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -33906,7 +33965,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
@@ -33935,7 +33994,7 @@
       "requires": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
@@ -33949,7 +34008,7 @@
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "requires": {
-        "@types/node": "20.8.3",
+        "@types/node": "*",
         "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
@@ -38675,6 +38734,12 @@
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@types/lodash": "^4.14.202",
         "@types/markdown-it": "^13.0.7",
         "@types/markdown-it-footnote": "^3.0.3",
-        "@types/node": "^20.11.16",
+        "@types/node": "20.8.3",
         "@types/react": "^18.2.53",
         "@types/react-dom": "^18.2.18",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -6839,15 +6839,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.19.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-      "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/@storybook/core-common/node_modules/esbuild": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -6984,15 +6975,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-      "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@storybook/core-server/node_modules/fs-extra": {
@@ -7383,15 +7365,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
-    },
-    "node_modules/@storybook/react/node_modules/@types/node": {
-      "version": "18.19.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-      "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
     },
     "node_modules/@storybook/react/node_modules/acorn": {
       "version": "7.4.1",
@@ -8363,13 +8336,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.3.tgz",
+      "integrity": "sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.11",
@@ -21498,12 +21468,6 @@
         "node": ">=14.0"
       }
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -25594,7 +25558,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "chalk": "^4.0.0",
         "jest-message-util": "^29.7.0",
         "jest-util": "^29.7.0",
@@ -25612,7 +25576,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -25645,7 +25609,7 @@
       "requires": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "jest-mock": "^29.7.0"
       }
     },
@@ -25676,7 +25640,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "jest-message-util": "^29.7.0",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
@@ -25706,7 +25670,7 @@
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -25837,7 +25801,7 @@
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       }
@@ -27141,7 +27105,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
+            "@types/node": "20.8.3",
             "@types/yargs": "^16.0.0",
             "chalk": "^4.0.0"
           }
@@ -27162,7 +27126,7 @@
           "dev": true,
           "requires": {
             "@jest/types": "^27.5.1",
-            "@types/node": "*"
+            "@types/node": "20.8.3"
           }
         }
       }
@@ -27712,7 +27676,7 @@
         "@storybook/node-logger": "7.6.12",
         "@storybook/types": "7.6.12",
         "@types/find-cache-dir": "^3.2.1",
-        "@types/node": "^18.0.0",
+        "@types/node": "20.8.3",
         "@types/node-fetch": "^2.6.4",
         "@types/pretty-hrtime": "^1.0.0",
         "chalk": "^4.1.0",
@@ -27887,15 +27851,6 @@
           "dev": true,
           "optional": true
         },
-        "@types/node": {
-          "version": "18.19.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-          "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        },
         "esbuild": {
           "version": "0.18.20",
           "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -27985,7 +27940,7 @@
         "@storybook/telemetry": "7.6.12",
         "@storybook/types": "7.6.12",
         "@types/detect-port": "^1.3.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "20.8.3",
         "@types/pretty-hrtime": "^1.0.0",
         "@types/semver": "^7.3.4",
         "better-opn": "^3.0.2",
@@ -28012,15 +27967,6 @@
         "ws": "^8.2.3"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.19.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-          "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        },
         "fs-extra": {
           "version": "11.2.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -28229,7 +28175,7 @@
         "@storybook/types": "7.6.12",
         "@types/escodegen": "^0.0.6",
         "@types/estree": "^0.0.51",
-        "@types/node": "^18.0.0",
+        "@types/node": "20.8.3",
         "acorn": "^7.4.1",
         "acorn-jsx": "^5.3.1",
         "acorn-walk": "^7.2.0",
@@ -28248,15 +28194,6 @@
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
           "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
           "dev": true
-        },
-        "@types/node": {
-          "version": "18.19.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
-          "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
         },
         "acorn": {
           "version": "7.4.1",
@@ -28771,7 +28708,7 @@
       "integrity": "sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/body-parser": {
@@ -28781,7 +28718,7 @@
       "dev": true,
       "requires": {
         "@types/connect": "*",
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/chai": {
@@ -28796,7 +28733,7 @@
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/cookie": {
@@ -28810,7 +28747,7 @@
       "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/debug": {
@@ -28885,7 +28822,7 @@
       "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
@@ -28904,7 +28841,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/graceful-fs": {
@@ -28913,7 +28850,7 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/hast": {
@@ -29048,13 +28985,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
-      "dev": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.3.tgz",
+      "integrity": "sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw==",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.6.11",
@@ -29062,7 +28996,7 @@
       "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "form-data": "^4.0.0"
       }
     },
@@ -29072,7 +29006,7 @@
       "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/normalize-package-data": {
@@ -29150,7 +29084,7 @@
       "dev": true,
       "requires": {
         "@types/mime": "^1",
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/serve-static": {
@@ -29161,7 +29095,7 @@
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",
-        "@types/node": "*"
+        "@types/node": "20.8.3"
       }
     },
     "@types/stack-utils": {
@@ -31926,7 +31860,7 @@
       "integrity": "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "require-like": ">= 0.1.1"
       }
     },
@@ -33529,7 +33463,7 @@
         "@jest/expect": "^29.7.0",
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^1.0.0",
@@ -33691,7 +33625,7 @@
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
       }
@@ -33710,7 +33644,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
@@ -33768,7 +33702,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "jest-util": "^29.7.0"
       }
     },
@@ -33836,7 +33770,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
@@ -33885,7 +33819,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -33972,7 +33906,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
@@ -34001,7 +33935,7 @@
       "requires": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
@@ -34015,7 +33949,7 @@
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
+        "@types/node": "20.8.3",
         "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
@@ -38741,12 +38675,6 @@
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/lodash": "^4.14.202",
     "@types/markdown-it": "^13.0.7",
     "@types/markdown-it-footnote": "^3.0.3",
-    "@types/node": "20.8.3",
     "@types/react": "^18.2.53",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -84,8 +83,5 @@
     "clean-cache": "rimraf .cache .wrangler node_modules/.cache build public/build",
     "storybook": "storybook dev -p 6006"
   },
-  "main": "build/index.js",
-  "overrides": {
-    "@types/node": "20.8.3"
-  }
+  "main": "build/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/lodash": "^4.14.202",
     "@types/markdown-it": "^13.0.7",
     "@types/markdown-it-footnote": "^3.0.3",
-    "@types/node": "^20.11.16",
+    "@types/node": "20.8.3",
     "@types/react": "^18.2.53",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -84,5 +84,8 @@
     "clean-cache": "rimraf .cache .wrangler node_modules/.cache build public/build",
     "storybook": "storybook dev -p 6006"
   },
-  "main": "build/index.js"
+  "main": "build/index.js",
+  "overrides": {
+    "@types/node": "20.8.3"
+  }
 }


### PR DESCRIPTION
I noticed that stampy.ts tests are failing (e.g. https://github.com/StampyAI/stampy-ui/actions/runs/7854687158/job/21435971107) with the following error:
```
    app/server-utils/stampy.ts:196:45 - error TS2576: Property 'json' does not exist on type 'Response'. Did you mean to access the static member 'Response.json' instead?

    196     json = await (await fetch(url, params)).json()
```
I think it is due to the types conflict described [here](https://github.com/cloudflare/workerd/issues/1298).

This PR removes `@types/node` to remove the conflict. This doesn't seem to break the app or any tests.