### PR TITLE
redirect ?state urls (#382 part 1)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@ rules:
   react-hooks/rules-of-hooks: error
   react-hooks/exhaustive-deps: error
   "@typescript-eslint/no-explicit-any": off
+  "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_"}]
   react/no-unescaped-entities: ["error", {"forbid": [">", "}"]}]
   unused-imports/no-unused-imports: "error"
 settings:

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import type {LoaderFunction} from '@remix-run/cloudflare'
-import {ShouldRevalidateFunction, useOutletContext, useLoaderData} from '@remix-run/react'
-import {loadTags} from '~/server-utils/stampy'
+import {ShouldRevalidateFunction, useOutletContext, useLoaderData, redirect} from '@remix-run/react'
+import {QuestionState, loadTags} from '~/server-utils/stampy'
 import Header from '~/components/Header'
 import Footer from '~/components/Footer'
 import type {Context} from '~/root'
@@ -10,9 +10,22 @@ import {PageSubheaderText} from '~/components/PageSubHeader'
 import {ContentBoxMain, ContentBoxSecond, ContentBoxThird} from '~/components/ContentBox'
 import Grid from '~/components/Grid'
 import useToC from '~/hooks/useToC'
+import {getStateEntries} from '~/hooks/stateModifiers'
 
 const empty: Awaited<ReturnType<typeof loadTags>> = {data: [], timestamp: ''}
 export const loader = async ({request}: Parameters<LoaderFunction>[0]) => {
+  const url = new URL(request.url)
+  const stateFromUrl = url.searchParams.get('state')
+  if (stateFromUrl) {
+    const firstOpenId = getStateEntries(stateFromUrl).filter(
+      ([_, state]) => state === QuestionState.OPEN
+    )[0]?.[0]
+    if (firstOpenId) {
+      url.searchParams.delete('state')
+      url.pathname = `/${firstOpenId}`
+      throw redirect(url.toString())
+    }
+  }
   try {
     const tags = await loadTags(request)
     return {tags}


### PR DESCRIPTION
* server-side redirect in remix loader
* no parser update yet (articles still have old links in the text)
* preserving `?question=...` url search param (not converting to title-in-url yet)