### PR TITLE
feat(newRoot.css): add margin-left to .group-elements

### DIFF
--- a/app/newRoot.css
+++ b/app/newRoot.css
@@ -411,4 +411,5 @@ a:not(:hover, :focus-visible) {
   flex-direction: row;
   justify-content: flex-start;
   gap: 10.9vw;
+  margin-left: 5.56vw;
 }


### PR DESCRIPTION
Trying to move the categories nav into the correct location. Relates to #379 

I did this by adding some margin
![image](https://github.com/StampyAI/stampy-ui/assets/4407464/621d0b24-8891-4fcf-a28d-927d0ab9b011)

I think this matches figma now, but I'm not sure if `margin-left` on `.group-elements` is the best way to do this. Let me know your thoughts!

![image](https://github.com/StampyAI/stampy-ui/assets/4407464/5dde7846-b6a5-4c1a-ae44-1ccc93d60bbc)
