### PR TITLE
feat(menu.module.css): padding to category to fix active highlighting

### DIFF
--- a/app/components/CategoriesNav/menu.module.css
+++ b/app/components/CategoriesNav/menu.module.css
@@ -15,6 +15,7 @@
   align-items: flex-start;
   margin: 5px;
   position: relative;
+  padding: 0px 10px 0px 24px;
 }
 .categoryAutoLayoutHorizontal.active {
   background-color: rgba(237.0000010728836, 250.00000029802322, 249.00000035762787, 1);


### PR DESCRIPTION
Relates to #379 . Adds padding so that active category is closer to figma

![image](https://github.com/StampyAI/stampy-ui/assets/4407464/9ec84a3c-444b-4521-ab99-e201a5c272c0)
