### PR TITLE
Search results not redirecting. FIX: increase the `hide` timer, which…

### DIFF
--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -68,7 +68,7 @@ export default function Search({queryFromUrl, limitFromUrl, removeQueryFromUrl}:
   const handleChange = debounce(searchFn, 100)
 
   const handleBlur = () => {
-    setTimeout(() => setShowResults(false), 100)
+    setTimeout(() => setShowResults(false), 500)
   }
 
   return (


### PR DESCRIPTION
… caused the Link component to be destroyed before the user is redirected to its `to=` value.