### PR TITLE
fix(questions route): add black class to mobile nav button

### DIFF
--- a/app/routes/questions.$questionId.$.tsx
+++ b/app/routes/questions.$questionId.$.tsx
@@ -119,7 +119,7 @@ export default function RenderArticle() {
           </div>
         ) : (
           <Button
-            className="mobile-only article-selector large-reading"
+            className="mobile-only article-selector large-reading black"
             action={() => setShowNav(true)}
           >
             {getArticle(pageid)?.title}


### PR DESCRIPTION
Fixes: #531 

From the figma, I think this colour should be `cool grey 900`
![image](https://github.com/StampyAI/stampy-ui/assets/4407464/d8a2915e-3ce5-4d8a-be36-d37226f69cb0)

But from the css, `cool-grey-900` is defined [to be the same as black](https://github.com/StampyAI/stampy-ui/blob/master/app/newRoot.css#L6). And as [we have a class for black](https://github.com/StampyAI/stampy-ui/blob/dd1e10e185326fcbffbb4b9ef4abfbc3944bd4da/app/newRoot.css#L164) but no class for cool grey 900, I figured I would go ahead with adding the `black` class.

I tested fix on safari on Iphone (where I was able to reproduce this error previously).