### PR TITLE
chore(storybook preview): use RemixStub decorator

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,17 +1,23 @@
-import {BrowserRouter} from 'react-router-dom'
+import {createRemixStub} from '@remix-run/testing'
 import type {Preview} from '@storybook/react'
 import {CachedObjectsProvider} from '../app//hooks/useCachedObjects'
 
 import '../app/newRoot.css'
 
 export const decorators = [
-  (Story) => (
-    <CachedObjectsProvider>
-      <BrowserRouter>
-        <Story />
-      </BrowserRouter>
-    </CachedObjectsProvider>
-  ),
+  (Story) => {
+    const RemixStub = createRemixStub([
+      {
+        path: '*',
+        Component: () => <Story />,
+      },
+    ])
+    return (
+      <CachedObjectsProvider>
+          <RemixStub />
+      </CachedObjectsProvider>
+    )
+  },
 ]
 
 const preview: Preview = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240129.0",
         "@remix-run/dev": "^2.6.0",
+        "@remix-run/testing": "^2.6.0",
         "@storybook/addon-designs": "^7.0.9",
         "@storybook/addon-essentials": "^7.6.8",
         "@storybook/addon-interactions": "^7.6.8",
@@ -5024,14 +5025,14 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.6.0.tgz",
-      "integrity": "sha512-m/Ph6bryny7wrmrQyXQMvIiW+cBLrU/MepcLGFPvTVVwvfeiGBgXRiYZJ6yPNsfrmHFaS83d+Ja/Mx4N4zUWcg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.8.1.tgz",
+      "integrity": "sha512-HTPm1U8+xz2jPaVjZnssrckfmFMA8sUZUdaWnoF5lmLWdReqcQv+XlBhIrQQ3jO9L8iYYdnzaSZZcRFYSdpTYg==",
       "dependencies": {
-        "@remix-run/router": "1.15.0",
-        "@remix-run/server-runtime": "2.6.0",
-        "react-router": "6.22.0",
-        "react-router-dom": "6.22.0"
+        "@remix-run/router": "1.15.3",
+        "@remix-run/server-runtime": "2.8.1",
+        "react-router": "6.22.3",
+        "react-router-dom": "6.22.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5039,6 +5040,38 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/react/node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remix-run/react/node_modules/@remix-run/server-runtime": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.8.1.tgz",
+      "integrity": "sha512-fh4SOEoONrN73Kvzc0gMDCmYpVRVbvoj9j3BUXHAcn0An8iX+HD/22gU7nTkIBzExM/F9xgEcwTewOnWqLw0Bg==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.6.0",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -5061,6 +5094,91 @@
       "integrity": "sha512-qFXDl4pK55njBLuvyRn5AkI/hu8fEU3t1XFKv0Syivx0nmUVpWMW25Uzi1pkX/chF1VIxCVrZ8KuQ1rcrKj+DQ==",
       "dependencies": {
         "@remix-run/router": "1.15.0",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.6.0",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/testing": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/testing/-/testing-2.8.1.tgz",
+      "integrity": "sha512-1bWTzjJ6zSWSTjFLeuuXpA7JKPTw39sYCnHZyMdIkBIAxkV/ez6eE8U1BQN+QBlBZYcj7uh0yrKT5XC9rJpvMA==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/node": "2.8.1",
+        "@remix-run/react": "2.8.1",
+        "@remix-run/router": "1.15.3",
+        "react-router-dom": "6.22.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/testing/node_modules/@remix-run/node": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.8.1.tgz",
+      "integrity": "sha512-ddCwBVlfLvRxTQJHPcaM1lhfMjsFYG3EGmYpWJIWnnzDX5EbX9pUNHBWisMuH1eA0c7pbw0PbW0UtCttKYx2qg==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/server-runtime": "2.8.1",
+        "@remix-run/web-fetch": "^4.4.2",
+        "@remix-run/web-file": "^3.1.0",
+        "@remix-run/web-stream": "^1.1.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/testing/node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remix-run/testing/node_modules/@remix-run/server-runtime": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.8.1.tgz",
+      "integrity": "sha512-fh4SOEoONrN73Kvzc0gMDCmYpVRVbvoj9j3BUXHAcn0An8iX+HD/22gU7nTkIBzExM/F9xgEcwTewOnWqLw0Bg==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
@@ -18933,11 +19051,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
-      "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "dependencies": {
-        "@remix-run/router": "1.15.0"
+        "@remix-run/router": "1.15.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -18947,12 +19065,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.0.tgz",
-      "integrity": "sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "dependencies": {
-        "@remix-run/router": "1.15.0",
-        "react-router": "6.22.0"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -18960,6 +19078,22 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/react-router/node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -26785,14 +26919,34 @@
       }
     },
     "@remix-run/react": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.6.0.tgz",
-      "integrity": "sha512-m/Ph6bryny7wrmrQyXQMvIiW+cBLrU/MepcLGFPvTVVwvfeiGBgXRiYZJ6yPNsfrmHFaS83d+Ja/Mx4N4zUWcg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.8.1.tgz",
+      "integrity": "sha512-HTPm1U8+xz2jPaVjZnssrckfmFMA8sUZUdaWnoF5lmLWdReqcQv+XlBhIrQQ3jO9L8iYYdnzaSZZcRFYSdpTYg==",
       "requires": {
-        "@remix-run/router": "1.15.0",
-        "@remix-run/server-runtime": "2.6.0",
-        "react-router": "6.22.0",
-        "react-router-dom": "6.22.0"
+        "@remix-run/router": "1.15.3",
+        "@remix-run/server-runtime": "2.8.1",
+        "react-router": "6.22.3",
+        "react-router-dom": "6.22.3"
+      },
+      "dependencies": {
+        "@remix-run/router": {
+          "version": "1.15.3",
+          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+          "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w=="
+        },
+        "@remix-run/server-runtime": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.8.1.tgz",
+          "integrity": "sha512-fh4SOEoONrN73Kvzc0gMDCmYpVRVbvoj9j3BUXHAcn0An8iX+HD/22gU7nTkIBzExM/F9xgEcwTewOnWqLw0Bg==",
+          "requires": {
+            "@remix-run/router": "1.15.3",
+            "@types/cookie": "^0.6.0",
+            "@web3-storage/multipart-parser": "^1.0.0",
+            "cookie": "^0.6.0",
+            "set-cookie-parser": "^2.4.8",
+            "source-map": "^0.7.3"
+          }
+        }
       }
     },
     "@remix-run/router": {
@@ -26811,6 +26965,56 @@
         "cookie": "^0.6.0",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
+      }
+    },
+    "@remix-run/testing": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/testing/-/testing-2.8.1.tgz",
+      "integrity": "sha512-1bWTzjJ6zSWSTjFLeuuXpA7JKPTw39sYCnHZyMdIkBIAxkV/ez6eE8U1BQN+QBlBZYcj7uh0yrKT5XC9rJpvMA==",
+      "dev": true,
+      "requires": {
+        "@remix-run/node": "2.8.1",
+        "@remix-run/react": "2.8.1",
+        "@remix-run/router": "1.15.3",
+        "react-router-dom": "6.22.3"
+      },
+      "dependencies": {
+        "@remix-run/node": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.8.1.tgz",
+          "integrity": "sha512-ddCwBVlfLvRxTQJHPcaM1lhfMjsFYG3EGmYpWJIWnnzDX5EbX9pUNHBWisMuH1eA0c7pbw0PbW0UtCttKYx2qg==",
+          "dev": true,
+          "requires": {
+            "@remix-run/server-runtime": "2.8.1",
+            "@remix-run/web-fetch": "^4.4.2",
+            "@remix-run/web-file": "^3.1.0",
+            "@remix-run/web-stream": "^1.1.0",
+            "@web3-storage/multipart-parser": "^1.0.0",
+            "cookie-signature": "^1.1.0",
+            "source-map-support": "^0.5.21",
+            "stream-slice": "^0.1.2"
+          }
+        },
+        "@remix-run/router": {
+          "version": "1.15.3",
+          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+          "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+          "dev": true
+        },
+        "@remix-run/server-runtime": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.8.1.tgz",
+          "integrity": "sha512-fh4SOEoONrN73Kvzc0gMDCmYpVRVbvoj9j3BUXHAcn0An8iX+HD/22gU7nTkIBzExM/F9xgEcwTewOnWqLw0Bg==",
+          "dev": true,
+          "requires": {
+            "@remix-run/router": "1.15.3",
+            "@types/cookie": "^0.6.0",
+            "@web3-storage/multipart-parser": "^1.0.0",
+            "cookie": "^0.6.0",
+            "set-cookie-parser": "^2.4.8",
+            "source-map": "^0.7.3"
+          }
+        }
       }
     },
     "@remix-run/web-blob": {
@@ -36791,20 +36995,34 @@
       }
     },
     "react-router": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
-      "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "requires": {
-        "@remix-run/router": "1.15.0"
+        "@remix-run/router": "1.15.3"
+      },
+      "dependencies": {
+        "@remix-run/router": {
+          "version": "1.15.3",
+          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+          "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w=="
+        }
       }
     },
     "react-router-dom": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.0.tgz",
-      "integrity": "sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "requires": {
-        "@remix-run/router": "1.15.0",
-        "react-router": "6.22.0"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
+      },
+      "dependencies": {
+        "@remix-run/router": {
+          "version": "1.15.3",
+          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+          "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w=="
+        }
       }
     },
     "react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240129.0",
     "@remix-run/dev": "^2.6.0",
+    "@remix-run/testing": "^2.6.0",
     "@svgr/cli": "^8.1.0",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.202",


### PR DESCRIPTION
Fixes #452

Using RemixStub in order to provide necessary remix context https://blog.sentiero.digital/how-to-run-remix-link-component-in-storybook

Also, remove BrowserRouter as it was causing double router and isn't required for Remix https://remix.run/docs/en/main/guides/migrating-react-router-app#adapting-your-existing-app-code

