### PR TITLE
Ticket #376

### DIFF
--- a/app/components/Article/Contents.tsx
+++ b/app/components/Article/Contents.tsx
@@ -156,7 +156,17 @@ const insertGlossary = (pageid: string, glossary: Glossary) => {
   }
 }
 
-const Contents = ({pageid, html, glossary}: {pageid: PageId; html: string; glossary: Glossary}) => {
+const Contents = ({
+  pageid,
+  html,
+  glossary,
+  className = '',
+}: {
+  pageid: PageId
+  html: string
+  glossary: Glossary
+  className?: string
+}) => {
   const elementRef = useRef<HTMLDivElement>(null)
   const mobile = useIsMobile()
 
@@ -194,7 +204,7 @@ const Contents = ({pageid, html, glossary}: {pageid: PageId; html: string; gloss
 
   return (
     <div
-      className="contents large-reading padding-bottom-80"
+      className={`contents large-reading ${className}`}
       dangerouslySetInnerHTML={{
         __html: html,
       }}

--- a/app/components/Article/index.tsx
+++ b/app/components/Article/index.tsx
@@ -148,7 +148,12 @@ export const Article = ({question, glossary, className}: ArticleProps) => {
       {question.banners?.filter((b) => b.title).map(Banner)}
       <ArticleMeta question={question} className="padding-bottom-56" />
 
-      <Contents pageid={pageid} html={text || ''} glossary={glossary || {}} />
+      <Contents
+        className="padding-bottom-80"
+        pageid={pageid}
+        html={text || ''}
+        glossary={glossary || {}}
+      />
 
       <KeepGoing {...question} />
 

--- a/app/components/Chatbot/ChatEntry.tsx
+++ b/app/components/Chatbot/ChatEntry.tsx
@@ -32,8 +32,12 @@ const AnswerInfo = ({
       <span className="small grey">
         {answerType === 'human' ? 'Human-written' : 'Bot-generated'} response
       </span>
-      <QuestionMarkIcon className="hint" />
-      <div className="hint-contents bordered xs">{hint}</div>
+      <div className="icon-container leading-0">
+        <QuestionMarkIcon className="hint" />
+        <div className="hint-contents-container">
+          <div className="hint-contents xs">{hint}</div>
+        </div>
+      </div>
     </span>
   )
 }

--- a/app/components/Chatbot/ChatEntry.tsx
+++ b/app/components/Chatbot/ChatEntry.tsx
@@ -33,7 +33,7 @@ const AnswerInfo = ({
         {answerType === 'human' ? 'Human-written' : 'Bot-generated'} response
       </span>
       <QuestionMarkIcon className="hint" />
-      <div className="hint-contents bordered">{hint}</div>
+      <div className="hint-contents bordered xs">{hint}</div>
     </span>
   )
 }

--- a/app/components/Chatbot/chat_entry.css
+++ b/app/components/Chatbot/chat_entry.css
@@ -47,6 +47,10 @@ article.stampy {
   visibility: visible;
 }
 
+.chat-entry .footnotes {
+  padding-top: var(--spacing-32);
+}
+
 .chat-entry .reference-link {
   font-size: 12px;
   line-height: 12px;

--- a/app/components/Chatbot/chat_entry.css
+++ b/app/components/Chatbot/chat_entry.css
@@ -14,6 +14,7 @@ article.stampy {
 }
 
 .chat-entry .info {
+  position: relative;
   display: flex;
   gap: var(--spacing-8);
   align-items: center;
@@ -21,17 +22,19 @@ article.stampy {
 
 .chat-entry .hint-contents {
   position: absolute;
-  transform: translateY(var(--spacing-24));
+  top: -10px;
+  right: 0;
+  transform: translateX(-50%);
   visibility: hidden;
   width: 256px;
+  background: var(--colors-cool-grey-800);
+  color: white;
+  padding: var(--spacing-16);
 }
 
 .chat-entry .hint-contents:hover,
 .chat-entry .hint:hover + .hint-contents {
   visibility: visible;
-  background: var(--colors-cool-grey-800);
-  color: white;
-  padding: var(--spacing-16);
 }
 
 .chat-entry .reference-link {

--- a/app/components/Chatbot/chat_entry.css
+++ b/app/components/Chatbot/chat_entry.css
@@ -20,20 +20,30 @@ article.stampy {
   align-items: center;
 }
 
-.chat-entry .hint-contents {
-  position: absolute;
-  top: -10px;
-  right: 0;
-  transform: translateX(-50%);
-  visibility: hidden;
-  width: 256px;
-  background: var(--colors-cool-grey-800);
-  color: white;
-  padding: var(--spacing-16);
+.chat-entry .icon-container {
+  position: relative;
 }
 
-.chat-entry .hint-contents:hover,
-.chat-entry .hint:hover + .hint-contents {
+.chat-entry .hint-contents-container {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translateX(50%);
+  visibility: hidden;
+  width: 256px;
+  padding-top: 120%;
+  z-index: 100;
+}
+
+.chat-entry .hint-contents {
+  background: var(--colors-cool-grey-900);
+  color: white;
+  padding: var(--spacing-16);
+  border-radius: var(--border-radius);
+}
+
+.chat-entry .hint-contents-container:hover,
+.chat-entry .hint:hover + .hint-contents-container {
   visibility: visible;
 }
 


### PR DESCRIPTION
I've improved the hint styling for human-written responses, but not the other part of this ticket which was about improving the padding/spacing for articles. From my understanding, the styling for articles is done through some magic which converts google docs pages into well styled html. I think the way to fix spacing here is just to add/remove spaces in the docs