### PR TITLE
Ticket-#597 - Reference Hover

### DIFF
--- a/app/components/Chatbot/ChatEntry.tsx
+++ b/app/components/Chatbot/ChatEntry.tsx
@@ -110,7 +110,7 @@ const ReferencePopup = (citation: Citation) => {
       <ReferenceSummary {...citation} titleClass="large-bold" />
       <div className="grey padding-bottom-16 padding-top-32 xs">Referenced excerpt</div>
       <div
-        className="default"
+        className="default inner-html"
         dangerouslySetInnerHTML={{
           __html: md.render(parsed[1]),
         }}

--- a/app/components/Chatbot/ChatEntry.tsx
+++ b/app/components/Chatbot/ChatEntry.tsx
@@ -106,7 +106,7 @@ const ReferencePopup = (citation: Citation) => {
   const parsed = citation.text?.match(/^###.*?###\s+"""(.*?)"""$/ms)
   if (!parsed) return undefined
   return (
-    <div className="reference-contents bordered">
+    <div className="reference-contents bordered z-index-2">
       <ReferenceSummary {...citation} titleClass="large-bold" />
       <div className="grey padding-bottom-16 padding-top-32 xs">Referenced excerpt</div>
       <div
@@ -124,12 +124,12 @@ const ReferenceLink = (citation: Citation) => {
   if (!index || index > MAX_REFERENCES) return ''
 
   return (
-    <>
+    <span className="ref-container">
       <Link id={`${id}-ref`} to={`#${id}`} className={`reference-link ref-${index}`}>
         <span>{index}</span>
       </Link>
       <ReferencePopup {...citation} />
-    </>
+    </span>
   )
 }
 

--- a/app/components/Chatbot/chat_entry.css
+++ b/app/components/Chatbot/chat_entry.css
@@ -149,9 +149,7 @@ article.stampy {
   visibility: hidden;
   transition: visibility 0.2s;
   width: 512px;
-  height: 509px;
   word-wrap: break-word;
-  overflow: hidden;
   background-color: white;
   border: 1px solid var(--colors-cool-grey-200, #dfe3e9);
   padding: var(--spacing-40);
@@ -160,16 +158,10 @@ article.stampy {
   text-decoration: unset;
   right: 0px;
   top: 40px;
-
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: var(--spacing-40);
-    background-color: white;
-  }
+}
+.reference-contents .inner-html {
+  height: 275px;
+  overflow: hidden;
 }
 
 .reference-contents:hover,

--- a/app/components/Chatbot/chat_entry.css
+++ b/app/components/Chatbot/chat_entry.css
@@ -75,6 +75,9 @@ article.stampy {
   display: inline-block;
   text-align: center;
 }
+.ref-container {
+  position: relative;
+}
 
 .ref-1 {
   background: #dbffed;
@@ -145,15 +148,28 @@ article.stampy {
 .reference-contents {
   visibility: hidden;
   transition: visibility 0.2s;
-  max-width: 600px;
+  width: 512px;
+  height: 509px;
   word-wrap: break-word;
+  overflow: hidden;
   background-color: white;
   border: 1px solid var(--colors-cool-grey-200, #dfe3e9);
   padding: var(--spacing-40);
   position: absolute;
   transform: translateX(50%);
   text-decoration: unset;
-  z-index: 3;
+  right: 0px;
+  top: 40px;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: var(--spacing-40);
+    background-color: white;
+  }
 }
 
 .reference-contents:hover,

--- a/app/components/Chatbot/index.tsx
+++ b/app/components/Chatbot/index.tsx
@@ -78,7 +78,10 @@ const QuestionInput = ({
   }
 
   return (
-    <div className={'widget-ask ' + (fixed ? 'fixed col-10' : 'col-9')} ref={clickDetectorRef}>
+    <div
+      className={'widget-ask ' + (fixed ? 'fixed col-10 z-index-4' : 'col-9')}
+      ref={clickDetectorRef}
+    >
       {results.length > 0 ? (
         <Button className="full-width suggestion" action={() => handleAsk(results[0].title)}>
           <p className="default">{results[0].title}</p>


### PR DESCRIPTION
Ok so I think I've done it, except its a little bit janky. i.e. in order to get the height consistent and correct, instead of editing the dangerouslyPastedHTML I've just set the overflow: hidden, and set the height of the contents div to be one which generally doesn't seem to clip words. 

also, @melissasamworth I made a design decision to put the reference popup below the number (instead of above, which is on the figma), because I feel like it generally clips off less often because I notice I am more likely to be reading stuff at the top of the screen. I also like that the curser is closer to the title and link when its below. Anywho, I can change it if you disagree.

https://github.com/StampyAI/stampy-ui/assets/148247390/c8f3070f-706e-4456-97cf-4ab6180a28bb