### PR TITLE
hide in-progress banner in sub-sections #753

### DIFF
--- a/app/components/Article/index.tsx
+++ b/app/components/Article/index.tsx
@@ -149,6 +149,7 @@ type ArticleProps = {
 }
 export const Article = ({question, glossary, className}: ArticleProps) => {
   const {title, text, pageid} = question
+  console.debug('gg')
 
   return (
     <article className={`${className} ${isLoading(question) ? 'loading' : ''}`}>
@@ -156,12 +157,16 @@ export const Article = ({question, glossary, className}: ArticleProps) => {
       {question.banners?.filter((b) => b.title).map(Banner)}
       <ArticleMeta question={question} className="padding-bottom-56" />
 
-      <Contents
-        className="padding-bottom-80"
-        pageid={pageid}
-        html={text || ''}
-        glossary={glossary || {}}
-      />
+      {text ? (
+        <Contents
+          className="padding-bottom-80"
+          pageid={pageid}
+          html={text}
+          glossary={glossary || {}}
+        />
+      ) : (
+        <div className="padding-bottom-32" />
+      )}
 
       <KeepGoing {...question} />
 

--- a/app/routes/questions.$questionId.$.tsx
+++ b/app/routes/questions.$questionId.$.tsx
@@ -66,8 +66,15 @@ const updateRelated = (question: Question, allQuestions?: Question[]) => {
   }
 }
 
-const updateFields = (question: Question, tags?: Tag[], allQuestions?: Question[]) =>
-  updateTags(updateRelated(question, allQuestions), tags)
+const updateBanners = (question: Question, hideBanners?: boolean) =>
+  hideBanners ? {...question, banners: []} : question
+
+const updateFields = (
+  question: Question,
+  hideBanners?: boolean,
+  tags?: Tag[],
+  allQuestions?: Question[]
+) => updateTags(updateRelated(updateBanners(question, hideBanners), allQuestions), tags)
 
 export default function RenderArticle() {
   const location = useLocation()
@@ -80,6 +87,7 @@ export default function RenderArticle() {
   const {question} = useLoaderData<typeof loader>()
   const {toc, findSection, getArticle, getPath} = useToC()
   const section = findSection(location?.state?.section || pageid)
+  const hideBannersIfSubsection = section?.children?.some((c) => c.pageid === pageid)
 
   useEffect(() => {
     setShowNav(false)
@@ -153,6 +161,7 @@ export default function RenderArticle() {
                   <Article
                     question={updateFields(
                       resolvedQuestion.data as Question,
+                      hideBannersIfSubsection,
                       tags,
                       onSiteQuestions
                     )}


### PR DESCRIPTION
* fix #753
* deployed in https://stampy-ui2.aprillion.workers.dev/questions/NM1D - without in-progress banner if it's a subsection, https://stampy-ui2.aprillion.workers.dev/questions/8YFC still with the banner