### PR TITLE
Remove [See more...] from backend

### DIFF
--- a/app/components/Article/Contents.tsx
+++ b/app/components/Article/Contents.tsx
@@ -180,11 +180,6 @@ const Contents = ({
       const target = e.target as HTMLElement
       target.classList.toggle('visible')
     }
-    Array.from(document.getElementsByClassName('see-more')).forEach((e) => {
-      const elem = e.cloneNode(true)
-      elem.addEventListener('click', toggleClass)
-      e.replaceWith(elem)
-    })
 
     // In theory this could be extended to all links
     el.querySelectorAll('.footnote-ref > a').forEach((e) => {

--- a/app/components/Article/Contents.tsx
+++ b/app/components/Article/Contents.tsx
@@ -175,12 +175,6 @@ const Contents = ({
 
     updateTextNodes(el, insertGlossary(pageid, glossary))
 
-    const toggleClass = (e: Event) => {
-      e.preventDefault()
-      const target = e.target as HTMLElement
-      target.classList.toggle('visible')
-    }
-
     // In theory this could be extended to all links
     el.querySelectorAll('.footnote-ref > a').forEach((e) => {
       const footnote = footnoteHTML(el, e as HTMLAnchorElement)

--- a/app/components/Article/article.css
+++ b/app/components/Article/article.css
@@ -176,15 +176,6 @@ article .footer-comtainer {
   margin-bottom: var(--spacing-24);
   gap: var(--spacing-16);
 }
-article a.see-more:not(.visible) + div.see-more-contents {
-  display: none;
-}
-article a.see-more:after {
-  content: 'See more...';
-}
-article a.see-more.visible:after {
-  content: 'See less';
-}
 
 article .banner {
   padding: var(--spacing-12) var(--spacing-24);

--- a/app/server-utils/parsing-utils.ts
+++ b/app/server-utils/parsing-utils.ts
@@ -48,25 +48,8 @@ md.renderer.rules.footnote_caption = (tokens, idx) => {
   return n
 }
 
-export const convertToHtmlAndWrapInDetails = (markdown: string): string => {
-  // Recursively wrap any [See more...] segments in HTML Details
-  const seeMoreToken = 'SEE-MORE-BUTTON'
-  const wrap = ([chunk, ...rest]: string[]): string => {
-    if (!rest || rest.length == 0) return chunk
-    return `<div>${chunk}</div>
-           <a href="" class="see-more"></a>
-           <div class="see-more-contents">${wrap(rest)}</div>`
-  }
-  // Add magic to handle markdown shortcomings.
-  // The [See more...] button will be transformed into an empty link if processed.
-  // On the other hand, if the whole text isn't rendered as one, footnotes will break.
-  // To get round this, replace the [See more...] button with a magic string, render the
-  // markdown, then mangle the resulting HTML to add an appropriate button link
-  markdown = markdown.replaceAll(/\[[Ss]ee more\W*?\]/g, seeMoreToken)
-  markdown = md.render(markdown)
-  markdown = wrap(markdown.split(seeMoreToken))
-
-  return markdown
+export const convertMarkdownToHtml = (markdown: string): string => {
+  return md.render(markdown)
 }
 
 export const uniqueFootnotes = (html: string, pageid: string): string => {

--- a/app/server-utils/stampy.ts
+++ b/app/server-utils/stampy.ts
@@ -4,7 +4,7 @@ import {
   allLinksOnNewTab,
   uniqueFootnotes,
   urlToIframe,
-  convertToHtmlAndWrapInDetails,
+  convertMarkdownToHtml,
 } from '~/server-utils/parsing-utils'
 import {
   ALL_ANSWERS_TABLE,
@@ -255,7 +255,7 @@ const renderText = (pageid: PageId, markdown: string | null): string | null => {
   markdown = extractText(markdown)
   markdown = urlToIframe(markdown || '')
 
-  let html = convertToHtmlAndWrapInDetails(markdown)
+  let html = convertMarkdownToHtml(markdown)
   html = uniqueFootnotes(html, pageid)
   html = cleanUpDoubleBold(html)
   html = allLinksOnNewTab(html)


### PR DESCRIPTION
The feature has been broken for a while, the text was simply ignored by the parser. I have removed what I believe is all traces of it in the backend.

I have also made sure there are no articles (live or not) that contain the text **[See more** so we should not see any instances of this text showing up on the site. It has also been removed from all of our documentation.

There might be some legacy code to remove from GDocsRelatedThings, but if this is the case, I could not find it.