### PR TITLE
Increase footer spacing

### DIFF
--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -4,7 +4,7 @@ import './footer.css'
 const year = new Date().getFullYear()
 
 const Link = ({to, title}: {to: string; title: string}) => (
-  <div>
+  <div style={{marginBottom: '0.5rem'}}>
     <a href={to} target="_blank" rel="noreferrer">
       {title}
     </a>


### PR DESCRIPTION
Ref https://github.com/StampyAI/stampy-ui/issues/478

@melissasamworth I tried using `<div className="margin-bottom-8">` instead but it did not work, for reasons I did not understand. I don't expect my fix to break anything else since *Link* is defined locally.