### PR TITLE
Update advanced image ratio to 72x72

### DIFF
--- a/app/components/Grid/index.tsx
+++ b/app/components/Grid/index.tsx
@@ -4,7 +4,7 @@ import './grid.css'
 
 export const GridBox = ({title, subtitle, icon, pageid}: TOCItem) => (
   <a href={questionUrl({title, pageid})} className="grid-item bordered">
-    {icon && <img alt={title} width="72" height="80" src={icon} />}
+    {icon && <img alt={title} width="72" height="72" src={icon} />}
     <p className="large-bold">{title}</p>
     <div className="grid-description grey">{subtitle}</div>
   </a>


### PR DESCRIPTION
To address https://github.com/StampyAI/stampy-ui/issues/553

This is just a short-term fix, I think we might benefit from using icons instead of AI-generated images (see https://github.com/StampyAI/stampy-ui/issues/674), I might experiment with that.