### PR TITLE
Add icon to external links

### DIFF
--- a/app/root.css
+++ b/app/root.css
@@ -640,18 +640,27 @@ a:not(:hover, :focus-visible) {
   text-decoration: none;
 }
 
+.contents a[target='_blank'][href^='http']:not(.icon-link, .transparent-link) {
+  margin-right: 12px;
+}
+
 .contents a[target='_blank'][href^='http']:not(.icon-link, .transparent-link):after {
-  content: ' ';
-  display: inline-block;
+  content: '';
+  position: absolute;
   width: 10px;
   height: 10px;
   margin-left: 1px;
-  margin-bottom: 6px;
+  margin-top: 8px;
   -webkit-mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
   mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
   -webkit-mask-size: cover;
   mask-size: cover;
   background-color: currentColor;
+}
+
+sup {
+  /* external link icon above looks best when line-height does not change on lines with footnotes */
+  line-height: 1;
 }
 
 hr {

--- a/app/root.css
+++ b/app/root.css
@@ -641,21 +641,8 @@ a:not(:hover, :focus-visible) {
 }
 
 .contents a[target='_blank'][href^='http']:not(.icon-link, .transparent-link) {
-  margin-right: 12px;
-}
-
-.contents a[target='_blank'][href^='http']:not(.icon-link, .transparent-link):after {
-  content: '';
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  margin-left: 1px;
-  margin-top: 8px;
-  -webkit-mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
-  mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
-  -webkit-mask-size: cover;
-  mask-size: cover;
-  background-color: currentColor;
+  padding-right: 12px;
+  background: url('/assets/Icon_External_Link.svg') no-repeat top 3px right 1px / 10px 10px;
 }
 
 sup {

--- a/app/root.css
+++ b/app/root.css
@@ -640,16 +640,13 @@ a:not(:hover, :focus-visible) {
   text-decoration: none;
 }
 
-/* Only show external icon for links that have both target="_blank" AND start with http/https */
-a[target='_blank'][href^="http"]:not(.icon-link, .transparent-link):after {
+.contents a[target='_blank'][href^="http"]:not(.icon-link, .transparent-link):after {
   content: ' ';
   display: inline-block;
-  vertical-align: top;
-  width: 12px;
-  height: 12px;
-  margin-left: 2px;
-  margin-top: 8px;
-  /* Support both webkit and standard mask syntax */
+  width: 10px;
+  height: 10px;
+  margin-left: 1px;
+  margin-bottom: 6px;
   -webkit-mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
   mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
   -webkit-mask-size: cover;

--- a/app/root.css
+++ b/app/root.css
@@ -640,6 +640,23 @@ a:not(:hover, :focus-visible) {
   text-decoration: none;
 }
 
+/* Only show external icon for links that have both target="_blank" AND start with http/https */
+a[target='_blank'][href^="http"]:not(.icon-link, .transparent-link):after {
+  content: ' ';
+  display: inline-block;
+  vertical-align: top;
+  width: 12px;
+  height: 12px;
+  margin-left: 2px;
+  margin-top: 8px;
+  /* Support both webkit and standard mask syntax */
+  -webkit-mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
+  mask: url('/assets/Icon_External_Link.svg') no-repeat center center;
+  -webkit-mask-size: cover;
+  mask-size: cover;
+  background-color: currentColor;
+}
+
 hr {
   border: 1px solid var(--colors-cool-grey-200);
   border-bottom: 0;

--- a/app/root.css
+++ b/app/root.css
@@ -640,7 +640,7 @@ a:not(:hover, :focus-visible) {
   text-decoration: none;
 }
 
-.contents a[target='_blank'][href^="http"]:not(.icon-link, .transparent-link):after {
+.contents a[target='_blank'][href^='http']:not(.icon-link, .transparent-link):after {
   content: ' ';
   display: inline-block;
   width: 10px;

--- a/public/assets/Icon_External_Link.svg
+++ b/public/assets/Icon_External_Link.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- based on https://commons.wikimedia.org/wiki/File:Icon_External_Link.svg -->
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
-<path fill="transparent" stroke="#06D" stroke-width="10" d="m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z"/>
+<path fill="transparent" stroke="#146560" stroke-width="10" d="m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z"/>
 </svg>

--- a/public/assets/Icon_External_Link.svg
+++ b/public/assets/Icon_External_Link.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- based on https://commons.wikimedia.org/wiki/File:Icon_External_Link.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+<path fill="transparent" stroke="#06D" stroke-width="10" d="m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z"/>
+</svg>


### PR DESCRIPTION
fixes https://github.com/StampyAI/stampy-ui/issues/863

There were a few modifications compared to what was done in https://github.com/StampyAI/stampy-ui/pull/346, which Claude says give better compatibility, but @Aprillion LMK if it's wrong

![external_icon](https://github.com/user-attachments/assets/c3bfe7ac-cb40-4c4e-801d-dd905436353e)
