### PR TITLE
Update README and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Stampy!](https://github.com/StampyAI/StampyAIAssets/blob/main/profile/stampy-profile-228.png?raw=true)
 
-Stampy UI is an interface for [aisafety.info](https://aisafety.info), a questions and answers site about AGI safety, built with [Remix](https://remix.run/docs) and [Cloudflare Workers](https://developers.cloudflare.com/workers). When reading about existential risks becomes "too serious", we also have a more playful version of the site: [stampy.ai](https://stampy.ai).
+Stampy UI is an interface for [aisafety.info](https://aisafety.info), a questions and answers site about AGI safety, built with [Remix](https://remix.run/docs) and [Cloudflare Workers](https://developers.cloudflare.com/workers).
 
 Contributions are welcome, the code is released under the MIT License. If you'd like to join the [dev team](https://coda.io/d/AI-Safety-Info_dfau7sl2hmG/Dev-team_sulmV#_luYjG), drop by [our Discord](https://discord.com/invite/7wjJbFJnSN) and post in #stampy-dev!
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Contributions are welcome, the code is released under the MIT License. If you'd 
    - From the left menu `Compute (Workers)` : `Overview`, note your Cloudflare `Account ID` on the right
    - From the left menu `Storage & Databases` : `KV`, create a KV (key-value store) namespace `STAMPY_KV`
    - Note the new created `STAMPY_KV` Namespace ID
-   - Copy `wrangler.toml.template` to `wrangler.toml`
+   - Make a copy of `wrangler.toml.template` in the stampy-ui folder and name it `wrangler.toml`
    - Replace the values for your `{CLOUDFLARE_ACCT_ID}` and `{STAMPY_KV_ID}` in `wrangler.toml`
 
 4. Setup in [Coda.io](https://coda.io/account)

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prettier:fix": "prettier --write --ignore-path .gitignore \"**/*.{ts*,js,css,md,html}\"",
     "lint:fix": "tsc && npm run prettier:fix && npm run eslint:fix",
     "build": "rimraf public/build && npm run generate-icons && cross-env NODE_ENV=production remix build --sourcemap",
-    "start": "remix dev --manual -c 'wrangler dev ./build/index.js'",
+    "start": "cross-env remix dev --manual -c \"wrangler dev ./build/index.js\"",
     "dev": "npm run generate-icons && npm start",
     "tsc": "tsc",
     "wrangler": "wrangler",


### PR DESCRIPTION
I recently helped Algon setup a dev environment on his machine, I updated the README based on difficulties we had.

In particular, installing on a Windows machine had issues with quotes with this line
`"start": "remix dev --manual -c 'wrangler dev ./build/index.js'",`

I updated it based on a Claude suggestion to make it cross-platform, but I have not tested it.