### PR TITLE
Make Chat input multiline

### DIFF
--- a/app/components/Chatbot/index.tsx
+++ b/app/components/Chatbot/index.tsx
@@ -49,6 +49,28 @@ const QuestionInput = ({
     setQuestion('')
   }
 
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const sendButtonRef = useRef<SVGSVGElement>(null)
+  
+  const updateSendButtonPosition = () => {
+    const textarea = textareaRef.current
+    const sendButton = sendButtonRef.current
+    
+    if (textarea && sendButton) {
+      // Keep button aligned with first line for expanded textareas
+      const buttonTop = Math.min(textarea.clientHeight / 2, 30)
+      sendButton.style.top = `${buttonTop}px`
+    }
+  }
+  
+  // Initialize button position and update it whenever textarea changes
+  useEffect(() => {
+    updateSendButtonPosition()
+    // Slight delay to ensure textarea has resized
+    const timerId = setTimeout(updateSendButtonPosition, 50)
+    return () => clearTimeout(timerId)
+  }, [question])
+  
   const handleChange = (val: string) => {
     search(val, 0.7)
     setQuestion(val)
@@ -75,16 +97,23 @@ const QuestionInput = ({
           placeholder={placeholder}
           className="large full-width shadowed"
           value={question}
+          multiline={true}
+          textareaRef={textareaRef}
           onChange={(e) => handleChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Escape') {
               handleChange('')
-            } else if (e.key === 'Enter' && question.trim() && onAsk) {
+            } else if (e.key === 'Enter' && !e.shiftKey && question.trim() && onAsk) {
+              e.preventDefault();
               handleAsk(question)
             }
           }}
         />
-        <SendIcon className="send pointer" onClick={() => handleAsk(question)} />
+        <SendIcon 
+          ref={sendButtonRef}
+          className="send pointer" 
+          onClick={() => handleAsk(question)} 
+        />
       </div>
       {fixed && <div className="white-space" />}
 

--- a/app/components/Chatbot/widgit.css
+++ b/app/components/Chatbot/widgit.css
@@ -69,8 +69,11 @@
 
 .widget-ask .send {
   position: absolute;
-  right: var(--spacing-8);
-  bottom: var(--spacing-8);
+  right: var(--spacing-16);
+  top: 32px;
+  transform: translateY(-50%);
+  z-index: 5; /* Ensure the button stays above the scrollbar */
+  transition: top 0.1s ease; /* Match textarea's transition */
 }
 
 .white-space {

--- a/app/components/Input/index.tsx
+++ b/app/components/Input/index.tsx
@@ -1,4 +1,5 @@
 import './input.css'
+import { useRef, useEffect, RefObject } from 'react'
 
 type InputProps = {
   className?: string
@@ -8,11 +9,56 @@ type InputProps = {
   onChange?: (e: any) => void
   onKeyDown?: (e: any) => void
   onBlur?: (e: any) => void
+  multiline?: boolean
+  textareaRef?: RefObject<HTMLTextAreaElement>
 }
-const Input = ({className, ...props}: InputProps) => {
+const Input = ({className, multiline, textareaRef, ...props}: InputProps) => {
   const classes = ['input', className].filter((i) => i).join(' ')
+  const internalRef = useRef<HTMLTextAreaElement>(null)
+  
+  // Use provided ref or internal ref
+  const textareaReference = textareaRef || internalRef
 
-  return <input className={classes} {...props} />
+  // Auto-resize textarea based on content
+  useEffect(() => {
+    const resizeTextarea = () => {
+      const textarea = textareaReference.current
+      if (!textarea) return
+
+      // Reset height to auto to get the correct scrollHeight
+      textarea.style.height = 'auto'
+      
+      // Get the content height using scrollHeight which accounts for wrapped lines
+      const scrollHeight = textarea.scrollHeight
+      
+      // Get min and max heights from CSS
+      const minHeight = parseInt(getComputedStyle(textarea).minHeight)
+      const maxHeight = parseInt(getComputedStyle(textarea).maxHeight)
+      
+      // Choose height based on content, ensuring we stay within min/max bounds
+      const newHeight = Math.max(minHeight, Math.min(scrollHeight, maxHeight))
+      textarea.style.height = `${newHeight}px`
+      
+      // Hide scrollbar if not needed
+      if (scrollHeight <= maxHeight) {
+        textarea.style.overflowY = 'hidden'
+      } else {
+        textarea.style.overflowY = 'auto'
+      }
+    }
+
+    if (multiline) {
+      resizeTextarea()
+      // Run it again after a short delay to catch any layout shifts
+      setTimeout(resizeTextarea, 10)
+    }
+  }, [props.value, multiline, textareaReference])
+
+  return multiline ? (
+    <textarea ref={textareaReference} className={classes} {...props} />
+  ) : (
+    <input className={classes} {...props} />
+  )
 }
 
 export default Input

--- a/app/components/Input/input.css
+++ b/app/components/Input/input.css
@@ -15,6 +15,8 @@
   line-height: 170%; /* 27.2px */
   letter-spacing: -0.16px;
   transition: border 0.2s;
+  resize: none;
+  overflow-wrap: break-word;
 }
 
 /* I then define all properties from Figma as titles (e.g. 'size' and 'state' for input) */
@@ -29,6 +31,42 @@
   letter-spacing: -0.18px;
   padding-right: var(--height-64);
   padding-left: var(--spacing-16);
+}
+
+textarea.input {
+  min-height: var(--height-48);
+  max-height: calc(var(--height-48) * 3); /* Exactly 3x the original height */
+  overflow-y: auto;
+  padding-top: 12px; /* Better vertical alignment for single line text */
+  padding-right: var(--height-64); /* Space for send button */
+  width: 100%; /* Full width */
+  box-sizing: border-box;
+  resize: none;
+  line-height: 24px; /* Helps with consistent height calculation */
+  transition: height 0.1s ease;
+}
+
+textarea.input.large {
+  min-height: var(--height-64);
+  max-height: calc(var(--height-64) * 3); /* Exactly 3x the original height */
+  padding-top: 18px; /* Adjust for large input */
+  padding-right: calc(var(--height-64) + var(--spacing-8)); /* Space for send button */
+}
+
+/* Custom scrollbar styling */
+textarea.input::-webkit-scrollbar {
+  width: 8px;
+  margin-right: 10px;
+}
+
+textarea.input::-webkit-scrollbar-thumb {
+  background-color: var(--colors-cool-grey-300, #b8c4d2);
+  border-radius: 4px;
+}
+
+textarea.input::-webkit-scrollbar-track {
+  background-color: transparent;
+  margin-right: 20px;
 }
 
 /* states */


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/656

![single-line](https://github.com/user-attachments/assets/86b15cc0-cddd-49c0-8daa-6f85e4ef77c5)
![three-lines](https://github.com/user-attachments/assets/c6a1369e-ff62-4c37-852f-89ab3197161b)
![scrollbar](https://github.com/user-attachments/assets/48a3aa4f-fccc-40f5-af4f-dd168523ed4b)

There are a bunch of design decisions that ideally would have been taken around the position of the "send" key, I did something that made sense to me but I'm open to changing it

I also notice that when the text area expands, it eats up the questions above it. I think it's minor enough that it's fine.