### PR TITLE
Update glossary to no longer replace text if there are no replacements necessary

### DIFF
--- a/app/components/Article/Contents.tsx
+++ b/app/components/Article/Contents.tsx
@@ -86,7 +86,7 @@ const normalizeForComparison = (text: string): string => {
   return text
     .replace(/[‘’]/g, "'") // Replace left and right single quotes (U+2018, U+2019)
     .replace(/[“”]/g, '"') // Replace left and right double quotes (U+201C, U+201D)
-    .replace(/[–—]/g, '-') // Replace en-dash and em-dash with hyphen
+    .replace(/[‒–—]/g, '-') // Replace figure-dash, en-dash and em-dash with hyphen
 }
 
 const glossaryInjecter = (pageid: string, glossary: Glossary) => {

--- a/app/components/Article/Contents.tsx
+++ b/app/components/Article/Contents.tsx
@@ -81,20 +81,37 @@ const updateTextNodes = (el: Node, textProcessor: (node: Node) => Node) => {
  *  - an on hover popup with a short explaination of the glossary item
  *  - use each glossary item only once
  */
+const normalizeForComparison = (text: string): string => {
+  // Standardize single quotes and replace em-dashes with hyphens
+  // Use Unicode escape sequences for better editor compatibility
+  return text.replace(/\u2019/g, "'").replace(/\u2014/g, '-')
+}
+
 const glossaryInjecter = (pageid: string, glossary: Glossary) => {
   const seen = new Set()
-  return (html: string) =>
-    Object.values(glossary)
+  return (html: string) => {
+    // Normalize for comparison to find terms regardless of formatting
+    const normalizedHtml = normalizeForComparison(html)
+
+    return Object.values(glossary)
       .filter((item) => item.pageid != pageid)
       .sort((a, b) => (b.alias?.length ?? 0) - (a.alias?.length ?? 0))
-      .reduce((html, {term, alias}) => {
-        const match = new RegExp(`(^|[^\\w-])(${alias})($|[^\\w-])`, 'i')
-        if (!seen.has(term) && html.search(match) >= 0) {
+      .reduce((currentHtml, {term, alias}) => {
+        // Create a normalized pattern for matching variations in formatting
+        const normalizedAlias = normalizeForComparison(alias || '')
+        const match = new RegExp(`(^|[^\\w-])(${normalizedAlias})($|[^\\w-])`, 'i')
+
+        // Check if the term exists in the normalized HTML
+        if (!seen.has(term) && normalizedHtml.search(match) >= 0) {
           seen.add(term)
-          return html.replace(match, '$1<span class="glossary-entry">$2</span>$3')
+
+          // Use the canonical glossary term for consistent formatting
+          // Apply the replacement directly to the current HTML
+          return currentHtml.replace(match, `$1<span class="glossary-entry">${alias}</span>$3`)
         }
-        return html
+        return currentHtml
       }, html)
+  }
 }
 
 const insertGlossary = (pageid: string, glossary: Glossary) => {
@@ -105,7 +122,7 @@ const insertGlossary = (pageid: string, glossary: Glossary) => {
   const injecter = glossaryInjecter(pageid, glossary)
 
   return (textNode: Node) => {
-    const html = (textNode.textContent || '').replace('’', "'").replace('—', '-')
+    const html = textNode.textContent || ''
     // The glossary items have to be injected somewhere, so this does it by manually wrapping any known
     // definitions with spans. This is done from the longest to the shortest to make sure that sub strings
     // of longer definitions don't override them.

--- a/app/components/Article/Contents.tsx
+++ b/app/components/Article/Contents.tsx
@@ -82,9 +82,11 @@ const updateTextNodes = (el: Node, textProcessor: (node: Node) => Node) => {
  *  - use each glossary item only once
  */
 const normalizeForComparison = (text: string): string => {
-  // Standardize single quotes and replace em-dashes with hyphens
-  // Use Unicode escape sequences for better editor compatibility
-  return text.replace(/\u2019/g, "'").replace(/\u2014/g, '-')
+  // Standardize fancy quotes and dashes with their simpler equivalents
+  return text
+    .replace(/[‘’]/g, "'") // Replace left and right single quotes (U+2018, U+2019)
+    .replace(/[“”]/g, '"') // Replace left and right double quotes (U+201C, U+201D)
+    .replace(/[–—]/g, '-') // Replace en-dash and em-dash with hyphen
 }
 
 const glossaryInjecter = (pageid: string, glossary: Glossary) => {


### PR DESCRIPTION
fix https://github.com/StampyAI/stampy-ui/issues/923

It turns out that there was em-dash and quote replacement that was meant to normalize the glossary but applied even if there were not glossary hits. This led to seemingly random replacement of em-dashes to hyphen that would change upon refresh, which has annoyed @srkaas [for](https://discord.com/channels/677546901339504640/1125883308979535922/1300700976763899924) some [time](https://discord.com/channels/677546901339504640/1209956074984181830/1221869562035699774)