### PR TITLE
feat(Chatbot): disable submit on empty question

### DIFF
--- a/app/components/Chatbot/index.tsx
+++ b/app/components/Chatbot/index.tsx
@@ -84,7 +84,7 @@ const QuestionInput = ({
             }
           }}
         />
-        <SendIcon className="send pointer" onClick={() => handleAsk(question)} />
+        <SendIcon className="send pointer" onClick={() => question.trim() && handleAsk(question)} />
       </div>
       {fixed && <div className="white-space" />}
 


### PR DESCRIPTION
This PR prevents a chatbot question from being submitted when the question text is empty.

This addresses https://github.com/StampyAI/stampy-chat/issues/140 because the current UI behaviour is that the question text box is cleared when the submit button is clicked. So, with this change, a double click doesn't cause an issue because the text box is empty after the first submit so the second click on the submit button has no effect.

Submitting an empty query does seem to have any value currently as it just leads to the model commenting on its system prompt
![image](https://github.com/user-attachments/assets/5339ddd6-838f-4b0a-83a8-a2c0b4b55f12)
