### PR TITLE
Improve list paragraph spacing

### DIFF
--- a/app/components/Article/article.css
+++ b/app/components/Article/article.css
@@ -97,7 +97,6 @@ article .contents p + ol {
 /* Styling for list items */
 article .contents li {
   padding-bottom: var(--spacing-8);
-  line-height: 160%; /* Tighter line spacing within list items */
 }
 
 article .contents > p:has(> img) {

--- a/app/components/Article/article.css
+++ b/app/components/Article/article.css
@@ -77,19 +77,27 @@ article .contents a:visited {
 }
 
 article .contents p {
-  padding-bottom: var(--spacing-32);
+  padding-bottom: var(--spacing-24);
 }
 
 article .contents p:last-child {
   padding-bottom: 0;
 }
 
-article .contents li {
-  padding-bottom: var(--spacing-16);
+article .contents li:last-child {
+  padding-bottom: var(--spacing-24);
 }
 
-article .contents li:last-child {
-  padding-bottom: 0;
+/* If a list is preceded by a paragraph, reduce top margin */
+article .contents p + ul,
+article .contents p + ol {
+  margin-top: -16px;
+}
+
+/* Styling for list items */
+article .contents li {
+  padding-bottom: var(--spacing-8);
+  line-height: 160%; /* Tighter line spacing within list items */
 }
 
 article .contents > p:has(> img) {


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/613

Addresses spacing of list items. I also shrank the spacing between lines inside list items, IMO it makes it more readable.

The best way to test this is to actually run it in the dev environment, but here are a few screenshots

https://aisafety.info/questions/8185/What-is-Goodhart's-law
![goodhart](https://github.com/user-attachments/assets/b942ee92-aaad-40a6-a23b-53efb84d0b1b)

https://aisafety.info/questions/NM38/4:-The-road-from-human-level-to-superintelligent-AI-may-be-short
![road_superintelligence](https://github.com/user-attachments/assets/2b319119-2a8e-4f77-b431-3540351f01fb)

https://aisafety.info/questions/3485/What-are-accident-and-misuse-risks
![misuse](https://github.com/user-attachments/assets/fd28d5d0-0873-433e-88d8-3ee858244c4f)
