### PR TITLE
Standardize image size and captioning

### DIFF
--- a/app/components/Article/article.css
+++ b/app/components/Article/article.css
@@ -118,14 +118,14 @@ article .contents > p.image-caption {
   color: var(--colors-cool-grey-600);
   font-size: 0.9em;
   padding-top: 0;
-  margin-left: var(--spacing-40);
-  margin-right: var(--spacing-40);
+  margin-left: var(--spacing-24);
+  margin-right: var(--spacing-24);
 }
 
 article .contents img {
   /* this will sometimes stretch the image, which is better than having small images */
   /* see https://github.com/StampyAI/stampy-ui/issues/930 */
-  width: calc(100% - 40px);
+  width: calc(100% - 48px);
   height: auto;
   display: block;
   margin: 0 auto;

--- a/app/components/Article/article.css
+++ b/app/components/Article/article.css
@@ -123,7 +123,12 @@ article .contents > p.image-caption {
 }
 
 article .contents img {
-  max-width: 100%;
+  /* this will sometimes stretch the image, which is better than having small images */
+  /* see https://github.com/StampyAI/stampy-ui/issues/930 */
+  width: calc(100% - 40px);
+  height: auto;
+  display: block;
+  margin: 0 auto;
 }
 
 article .glossary-entry {
@@ -288,6 +293,12 @@ article blockquote + p {
 
   article {
     margin: 0;
+  }
+
+  /* Reset caption margins on mobile */
+  article .contents > p.image-caption {
+    margin-left: var(--spacing-16);
+    margin-right: var(--spacing-16);
   }
 }
 

--- a/app/components/MediaCarousel/index.tsx
+++ b/app/components/MediaCarousel/index.tsx
@@ -38,7 +38,7 @@ const MediaCarousel = ({items}: MediaCarouselProps) => {
   const [currentIndex, setCurrentIndex] = useState(0)
 
   return (
-    <div className="media-carousel-container padding-bottom-32">
+    <div className="media-carousel-container padding-bottom-16">
       <div className="media-carousel-track">
         <Media item={items[currentIndex]} />
       </div>

--- a/app/components/MediaCarousel/mediacarousel.css
+++ b/app/components/MediaCarousel/mediacarousel.css
@@ -14,7 +14,7 @@
 
 .media-carousel-track img,
 .media-carousel-track iframe {
-  width: calc(100% - 40px);
+  width: calc(100% - 48px);
   height: 100%;
   object-fit: contain;
   border: none;
@@ -30,8 +30,8 @@
 
 .media-carousel-title {
   margin-top: var(--spacing-12);
-  margin-left: var(--spacing-40);
-  margin-right: var(--spacing-40);
+  margin-left: var(--spacing-24);
+  margin-right: var(--spacing-24);
 }
 
 .media-carousel-index-indicator {

--- a/app/components/MediaCarousel/mediacarousel.css
+++ b/app/components/MediaCarousel/mediacarousel.css
@@ -14,21 +14,24 @@
 
 .media-carousel-track img,
 .media-carousel-track iframe {
-  width: 100%;
+  width: calc(100% - 40px);
   height: 100%;
   object-fit: contain;
   border: none;
+  margin: 0 auto;
+  display: block;
 }
 
 .media-carousel-navigation {
   display: flex;
   justify-content: center;
-  margin-top: var(--spacing-24);
+  margin-top: var(--spacing-16);
 }
 
 .media-carousel-title {
-  text-align: center;
-  margin-top: var(--spacing-16);
+  margin-top: var(--spacing-12);
+  margin-left: var(--spacing-40);
+  margin-right: var(--spacing-40);
 }
 
 .media-carousel-index-indicator {
@@ -36,4 +39,11 @@
   justify-content: center;
   align-items: center;
   width: 36px;
+}
+
+@media (max-width: 1136px) {
+  .media-carousel-title {
+    margin-left: var(--spacing-16);
+    margin-right: var(--spacing-16);
+  }
 }


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/930

Ended up not centering, but using margins as discussed.

Stretch images to text width minus 40px

Harmonize with MediaCarousel

Slightly reduce spacing around MediaCarousel navigation arrows

Non-carousel:

![new_image](https://github.com/user-attachments/assets/59d6aaea-e44f-4caf-91fe-37ccb952e690)

Within carousel:
![new_carousel](https://github.com/user-attachments/assets/cbdf4362-2869-4d49-81bc-cf07023c0f17)
