### PR TITLE
Remove images for Advanced sections on Frontpage

### DIFF
--- a/app/components/Grid/index.tsx
+++ b/app/components/Grid/index.tsx
@@ -2,9 +2,8 @@ import type {TOCItem} from '~/routes/questions.toc'
 import {questionUrl} from '~/routesMapper'
 import './grid.css'
 
-export const GridBox = ({title, subtitle, icon, pageid}: TOCItem) => (
+export const GridBox = ({title, subtitle, pageid}: TOCItem) => (
   <a href={questionUrl({title, pageid})} className="grid-item bordered">
-    {icon && <img alt={title} width="72" height="72" src={icon} />}
     <p className="large-bold">{title}</p>
     <div className="grid-description grey">{subtitle}</div>
   </a>


### PR DESCRIPTION
fix https://github.com/StampyAI/stampy-ui/issues/841

I just removed the images